### PR TITLE
Allow comments in feature weight files

### DIFF
--- a/tools/core/src/main/scala/org/allenai/nlpstack/conf/impl/LogisticRegression.scala
+++ b/tools/core/src/main/scala/org/allenai/nlpstack/conf/impl/LogisticRegression.scala
@@ -71,9 +71,12 @@ object LogisticRegression {
       using(Source.fromInputStream(input)) { source =>
         source.getLines.foreach { line =>
           val parts = tab.split(line)
-          val featureName = parts(0).trim
-          val weight = parts(1).toDouble
-          featureWeights += featureName -> weight
+          /* lines with no tabs are considered comment lines and ignored */
+          if (parts.length > 1) {
+            val featureName = parts(0).trim
+            val weight = parts(1).toDouble
+            featureWeights += featureName -> weight
+          }
         }
       }
 


### PR DESCRIPTION
@schmmd Just a simple change which ignores lines without tabs in feature weight specification files, letting you specify comments about where the weights are coming from (what training set, etc).
