### PR TITLE
Makes webapp find its static files

### DIFF
--- a/webapp/src/main/scala/org/allenai/nlpstack/webapp/BasicService.scala
+++ b/webapp/src/main/scala/org/allenai/nlpstack/webapp/BasicService.scala
@@ -6,7 +6,7 @@ import spray.http.MediaTypes._
 import spray.routing._
 
 trait BasicService extends HttpService {
-  val staticContentRoot = "public"
+  val staticContentRoot = "webapp/public"
 
   // format: OFF
   val basicRoute =


### PR DESCRIPTION
This version works on my machine. I suspect it might break the setup in production, but I don't know how to test that. We might never merge this, but I'm hoping we can have the discussion about it on here.

Why not put all the static files into the jar? Then we never have to worry about paths.

I accidentally pushed this to allenai:master. I reverted, committed and pushed, so allenai:master is unchanged again. It still shows in the history though, so that's why the history for both branches looks a bit messy.
