### PR TITLE
Fixes problem with multiple root nodes in DependencyGraph.collapse

### DIFF
--- a/tools/core/src/main/scala/org/allenai/nlpstack/parse/graph/DependencyGraph.scala
+++ b/tools/core/src/main/scala/org/allenai/nlpstack/parse/graph/DependencyGraph.scala
@@ -224,7 +224,7 @@ class DependencyGraph private (val root: Option[DependencyNode], vertices: Set[D
           collapseJunctions(
             collapseMultiwordPrepositions(this))))
 
-    DependencyGraph(graph.vertices, graph.edges)
+    DependencyGraph.withFirstRoot(graph.vertices, graph.edges)
   }
 
   /** Simplify xsubj and nsubj to just subj. */
@@ -289,6 +289,16 @@ object DependencyGraph {
     }
 
     this.apply(root, vertices, edges)
+  }
+
+  def withFirstRoot(vertices: Set[DependencyNode], edges: Set[Edge[DependencyNode]]) = {
+    val nodesWithIncomingEdges = edges.map(_.dest).toSet
+    val nodesWithoutIncomingEdges = vertices -- nodesWithIncomingEdges
+    if (nodesWithIncomingEdges.isEmpty)
+      throw new IllegalArgumentException("Graph is not a tree. No root node found.")
+    val firstRoot = nodesWithoutIncomingEdges.toSeq(0)
+
+    DependencyGraph(Some(firstRoot), vertices, edges)
   }
 
   def apply(dependencies: Iterable[Dependency]): DependencyGraph = {

--- a/tools/core/src/test/scala/org/allenai/nlpstack/parse/DependencyGraphSpec.scala
+++ b/tools/core/src/test/scala/org/allenai/nlpstack/parse/DependencyGraphSpec.scala
@@ -46,4 +46,24 @@ pobj(in-11, mirror-13)"""
     val repickled = DependencyParser.multilineStringFormat.write(dgraph)
     assert(multilinePickled === repickled)
   }
+
+  it should "find the first root if there are multiple" in {
+    val sentence = "Alice sings, John said."
+    val multilinePickled =
+      """|Alice 0 NNP
+         |sings 6 VBD
+         |, 11 .
+         |John 13 NNP
+         |said 18 VBD
+         |. 22 .
+         |
+         |nsubj(sings-2, Alice-1)
+         |root(ROOT-0, sings-2)
+         |nsubj(said-5, John-4)""".stripMargin
+
+    val (tokens, dgraph) = DependencyParser.multilineStringFormat.read(multilinePickled)
+    val collapsedGraph = dgraph.collapse
+
+    assert(DependencyParser.multilineStringFormat.write((tokens, collapsedGraph)) === multilinePickled)
+  }
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/PolytreeParser.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/PolytreeParser.scala
@@ -48,11 +48,7 @@ class PolytreeParser extends DependencyParser {
       new Graph.Edge(nodes(parentIndex - 1), nodes(childIndex - 1), label)
     }
 
-    val nodesWithIncomingEdges = edges.map(_.dest).toSet
-    val nodesWithoutIncomingEdges = nodes.toSet -- nodesWithIncomingEdges
-    val firstRoot = nodesWithoutIncomingEdges.toSeq(0)
-
-    DependencyGraph(Some(firstRoot), nodes.toSet, edges.toSet)
+    DependencyGraph.withFirstRoot(nodes.toSet, edges.toSet)
   }
 }
 


### PR DESCRIPTION
@raphaelhoffmann, @schmmd 

The problem is that some parses produce multiple trees. `DependencyGraph.apply()` can't deal with that. I added a helper function that finds the first root and uses that. This is the same code I used in the polyparser.
