### PR TITLE
Fixes collapsing

### DIFF
--- a/tools/core/src/main/scala/org/allenai/nlpstack/core/parse/graph/DependencyGraph.scala
+++ b/tools/core/src/main/scala/org/allenai/nlpstack/core/parse/graph/DependencyGraph.scala
@@ -228,7 +228,7 @@ class DependencyGraph private (val root: Option[DependencyNode], vertices: Set[D
 
       // if this transformation produced two root nodes, ignore the
       // transformation
-      if (newGraph.isTree)
+      if (newGraph.vertices.count(newGraph.indegree(_) == 0) == 1)
         newGraph
       else
         graph

--- a/tools/core/src/test/scala/org/allenai/nlpstack/core/DependencyGraphSpec.scala
+++ b/tools/core/src/test/scala/org/allenai/nlpstack/core/DependencyGraphSpec.scala
@@ -198,4 +198,28 @@ advmod(ran-4, away-5)"""
     assert(DependencyGraph.multilineStringFormat.write(uncollapsed.collapse) === expectedCollapsedString)
     assert(graphIsValid(uncollapsed.collapse))
   }
+
+  it should "allow collapsing output that's not a tree" in {
+    val uncollapsedString =
+      """|nsubj(enjoy-4, cats-1)
+         |cc(cats-1, and-2)
+         |conj(cats-1, dogs-3)
+         |root(ROOT-0, enjoy-4)
+         |det(arrow-6, an-5)
+         |dobj(enjoy-4, arrow-6)
+         |punct(enjoy-4, .-7)""".stripMargin
+    val uncollapsed = DependencyGraph.multilineStringFormat.read(uncollapsedString)
+
+    val expectedCollapsedString =
+      """|nsubj(enjoy-4, cats-1)
+         |conj_and(cats-1, dogs-3)
+         |nsubj(enjoy-4, dogs-3)
+         |root(ROOT-0, enjoy-4)
+         |det(arrow-6, an-5)
+         |dobj(enjoy-4, arrow-6)
+         |punct(enjoy-4, .-7)""".stripMargin
+
+    assert(DependencyGraph.multilineStringFormat.write(uncollapsed.collapse) === expectedCollapsedString)
+    assert(graphIsValid(uncollapsed.collapse))
+  }
 }


### PR DESCRIPTION
A while ago we changed collapsing so it would check whether the output is still a tree, and reject the transformation if it wasn't. Turns out, that's a problem. In the collapsed output of "Cats and dogs enjoy summer.", "dogs" has two parents, "and" and "enjoy", and that's a valid output.

I changed the check we do to be less strict. Now it only checks for there being only one root node.

@schmmd, you also reviewed the PR that broke this, so I thought you might be interested in the fix. Does this look good?
