### PR TITLE
Fix build; upgrade to latest plugins

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,6 +45,8 @@ object NlpstackBuild extends Build {
         "commons-codec" % "commons-codec" % "1.9",
         "org.scala-lang" % "scala-library" % scalaVersion.value,
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+        typesafeConfig,
+        allenAiCommon,
         slf4j,
         "commons-io" % "commons-io" % "2.4"))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "2014.11.24-0")
+addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "2014.12.04-0")

--- a/webapp/build.sbt
+++ b/webapp/build.sbt
@@ -5,18 +5,5 @@ name := "webapp"
 
 libraryDependencies ++= Seq(
   "commons-codec" % "commons-codec" % "1.9",
-  // server
-  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-  "io.spray" % "spray-can" % sprayVersion,
-  "io.spray" % "spray-routing" % sprayVersion,
-  "io.spray" %% "spray-json" % "1.2.6",
-  // config
-  "com.typesafe" % "config" % "1.2.0",
-  // vizualization
-  "org.riedelcastro" % "whatswrong" % "0.2.4") ++ loggingImplementations
-
-dependencyOverrides ++= Set(
-  "org.scala-lang" % "scala-library" % "2.10.4",
-  slf4j)
-
-mappings in Universal ++= directory(baseDirectory.value / "public")
+  "org.riedelcastro" % "whatswrong" % "0.2.4"
+)

--- a/webapp/webapp/package.json
+++ b/webapp/webapp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nlpstack-webapp",
+  "version": "0.0.0",
+  "description": "Webapp for shocasing nlpstack technologies",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No test specified\" && exit 0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/allenai/nlpstack"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/allenai/nlpstack/issues"
+  },
+  "homepage": "https://github.com/allenai/nlpstack"
+}


### PR DESCRIPTION
This fixes a build bug introduced by [this](https://github.com/allenai/nlpstack/commit/8b3be3287f3820e49816317d948747319e458d74#diff-215113124f1de02f228327ba7abb45f7L69).

I also upgraded the plugins to the latest version.

Note: the `webapp` project is enabling the `WebappPlugin` but not actually using the `npm` goodness. Instead of backing the use of the plugin out - I just stubbed out an `npm` project to make `npm` happy. We should properly move the sources in the `public` directory to the inner `webapp` directory and do a `gulp` build. I'm sure this is something @codeviking would love to do with some Syrup sometime soon :).
