### PR TITLE
Verbnet frame feature in reranker

### DIFF
--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/TransitionParser.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/TransitionParser.scala
@@ -111,13 +111,13 @@ object TransitionParser {
   def loadFromStream(stream: InputStream): TransitionParser = {
     println("Loading parser.")
     System.gc()
-    val initialMemory: Double = Runtime.getRuntime.totalMemory - Runtime.getRuntime.freeMemory()
+    val initialMemory = Runtime.getRuntime.totalMemory - Runtime.getRuntime.freeMemory()
     val result = convertJsValueToConfig(Util.getJsValueFromStream(stream))
     System.gc()
-    val memoryAfterLoading: Double = Runtime.getRuntime.totalMemory -
-      Runtime.getRuntime.freeMemory()
-    println("Parser memory footprint: %.1f MB".format((memoryAfterLoading - initialMemory)
-      / Math.pow(10.0, 6.0)))
+    val memoryAfterLoading = Runtime.getRuntime.totalMemory - Runtime.getRuntime.freeMemory()
+    println("Parser memory footprint: %.1f MB".format(
+      (memoryAfterLoading - initialMemory).toDouble / Math.pow(10.0, 6.0)
+    ))
     result
   }
 


### PR DESCRIPTION
@mhrmm : Verbnet features in the reranker. Not much of a change in scores. Tried using both frames and classes. Similar results either way. Also tried cutting down infrequent frames/classes. That didn't change scores much either. 

Changed the memory logging code to capture memory usage in `Longs` and then convert to `Double` just before dividing by 10^6. But something is wrong here. Sometimes I still get a -ve memory usage. I logged the before and after usage numbers and here's a snapshot of one of the runs-

```
[info] initialMemory: 233238840, memoryAfterLoading: 213369216
[info] Mem Diff: -19869624
```

May be the memory usage APIs used here are not reliable?
