### PR TITLE
Logging Weirdness Classifier incorrect results

### DIFF
--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/LabeledFeatureVectors.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/LabeledFeatureVectors.scala
@@ -1,6 +1,5 @@
 package org.allenai.nlpstack.parse.poly.ml
 
-import org.allenai.nlpstack.parse.poly.polyparser.{ LabeledFamily, PolytreeParse }
 import spray.json.DefaultJsonProtocol._
 
 /** Maps feature names to integers. Useful for serializing TrainingData instances for
@@ -19,9 +18,7 @@ object FeatureEncoding {
 /** Support structure to store a feature vector per parse family with associated label for expected
   * outcome.
   */
-case class LabeledFeatureVectorPerParseFamily(
-    sentence: String, family: LabeledFamily, featureVector: FeatureVector, expectedOutcome: Int
-) {
+case class LabeledFeatureVector(featureVector: FeatureVector, expectedOutcome: Int) {
 }
 
 /** Abstraction for a set of labeled feature vectors.
@@ -32,7 +29,7 @@ case class LabeledFeatureVectorPerParseFamily(
   * integer outcomes
   */
 case class LabeledFeatureVectors(
-    labeledVectors: Iterable[LabeledFeatureVectorPerParseFamily]
+    labeledVectors: Iterable[LabeledFeatureVector]
 ) {
 
   /** The set of feature names found in the training data. */

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
@@ -85,13 +85,15 @@ object WrapperClassifier {
   */
 class WrapperClassifierTrainer(classifierTrainer: ProbabilisticClassifierTrainer) {
 
-  def apply(trainingData: TrainingData): WrapperClassifier = {
+  def apply(trainingData: LabeledFeatureVectors): WrapperClassifier = {
     val featureNames: Seq[FeatureName] = trainingData.featureNames.toSeq
     val featureNameToIndex: Map[FeatureName, Int] = featureNames.zipWithIndex.toMap
     val vectors = new InMemoryFeatureVectorSource(
       (trainingData.labeledVectors map {
-      case (vec, outcome) =>
-        WrapperClassifier.createDTFeatureVector(vec, featureNameToIndex, Some(outcome))
+      x =>
+        WrapperClassifier.createDTFeatureVector(
+          x.featureVector, featureNameToIndex, Some(x.expectedOutcome)
+        )
     }).toIndexedSeq,
       SimpleTask("basic")
     )

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
@@ -464,7 +464,7 @@ object PolytreeParse {
   implicit val jsFormat = jsonFormat4(PolytreeParse.apply)
 }
 
-/** Support data structures used in PolytreeParse
+/** Support structures used in PolytreeParse
   */
 case class Node(tokenIndex: Int, token: Token)
 case class Family(nodes: Seq[Node])

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
@@ -468,4 +468,14 @@ object PolytreeParse {
   */
 case class Node(tokenIndex: Int, token: Token)
 case class Family(nodes: Seq[Node])
-case class LabeledFamily(node: Node, childArcsForNode: Seq[(Symbol, Node)])
+case class LabeledFamily(node: Node, childArcsForNode: Seq[(Symbol, Node)]) {
+  def prettyPrintNoTokenInfo: String = {
+    val nodeStr = "(" + node.tokenIndex + ", " + node.token.word.name + ") " + " -> "
+    val familyStrs = childArcsForNode map (family =>
+      "(" + family._1.name + ", " + "(" + family._2.tokenIndex + ", " +
+        family._2.token.word.name + "))")
+    val familyStr = familyStrs.mkString(", ")
+
+    nodeStr + familyStr
+  }
+}

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/RerankingParser.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/RerankingParser.scala
@@ -1,6 +1,6 @@
 package org.allenai.nlpstack.parse.poly.polyparser
 
-import org.allenai.nlpstack.parse.poly.core.Sentence
+import org.allenai.nlpstack.parse.poly.core.{ FactorieSentenceTagger, Sentence }
 import org.allenai.nlpstack.parse.poly.fsm._
 
 /** Uses the parser model to create an n-best list, then chooses the best parse from this n-best
@@ -37,9 +37,11 @@ case class RerankingTransitionParser(val config: ParserConfiguration) extends Tr
     val candidate: Option[Sculpture] = mappedNbestList flatMap { nbList => reranker(nbList) }
     candidate match {
       case Some(parse: PolytreeParse) =>
-        val mappedParse = parse.copy(sentence = Sentence(parse.sentence.tokens map { tok =>
-          tok.updateProperties(Map('cpos -> Set(tok.getDeterministicProperty('factorieCpos))))
-        }))
+        val mappedParse = parse.copy(sentence = Sentence(
+          FactorieSentenceTagger.transform(parse.sentence).tokens map { tok =>
+            tok.updateProperties(Map('cpos -> Set(tok.getDeterministicProperty('autoCpos))))
+          }
+        ))
         Some(mappedParse)
       case _ => None
     }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodExtractor.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodExtractor.scala
@@ -78,7 +78,7 @@ object NeighborhoodExtractor {
 case object AllChildrenExtractor extends NeighborhoodExtractor {
 
   override def apply(parse: PolytreeParse, token: Int): Seq[Neighborhood] = {
-    Seq(Neighborhood(parse.families(token).tail))
+    Seq(Neighborhood(parse.families(token).nodes.tail.map(_.tokenIndex)))
   }
 }
 
@@ -121,7 +121,7 @@ case class SpecificChildExtractor(k: Int) extends NeighborhoodExtractor {
 
   override def apply(parse: PolytreeParse, token: Int): Seq[Neighborhood] = {
     Seq(
-      parse.families(token).lift(k + 1) map { x => Neighborhood(Seq(x)) }
+      parse.families(token).nodes.lift(k + 1) map { x => Neighborhood(Seq(x.tokenIndex)) }
     ).flatten
   }
 }
@@ -133,9 +133,9 @@ case class SpecificChildExtractor(k: Int) extends NeighborhoodExtractor {
   */
 case class SpecificParentExtractor(parentIndex: Int) extends NeighborhoodExtractor {
 
-  override def apply(parse: PolytreeParse, token: Int): Seq[Neighborhood] = {
+  override def apply(parse: PolytreeParse, tokenIx: Int): Seq[Neighborhood] = {
     Seq(
-      parse.getParents().getOrElse(token, Seq[Int]()).lift(parentIndex) map { x =>
+      parse.getParents().getOrElse(tokenIx, Seq[Int]()).lift(parentIndex) map { x =>
         Neighborhood(Seq(x))
       }
     ).flatten
@@ -149,9 +149,9 @@ case class SpecificParentExtractor(parentIndex: Int) extends NeighborhoodExtract
   */
 case class SelfAndSpecificChildExtractor(k: Int) extends NeighborhoodExtractor {
 
-  override def apply(parse: PolytreeParse, token: Int): Seq[Neighborhood] = {
+  override def apply(parse: PolytreeParse, tokenIx: Int): Seq[Neighborhood] = {
     Seq(
-      parse.families(token).lift(k + 1) map { x => Neighborhood(Seq(x, token)) }
+      parse.families(tokenIx).nodes.lift(k + 1) map { x => Neighborhood(Seq(x.tokenIndex, tokenIx)) }
     ).flatten
   }
 }
@@ -175,8 +175,8 @@ case class SelfAndSpecificParentExtractor(parentIndex: Int) extends Neighborhood
 /** Extracts neighborhood (token) from the parse tree. */
 case object SelfExtractor extends NeighborhoodExtractor {
 
-  override def apply(parse: PolytreeParse, token: Int): Seq[Neighborhood] = {
-    Seq(Neighborhood(Seq(token)))
+  override def apply(parse: PolytreeParse, tokenIx: Int): Seq[Neighborhood] = {
+    Seq(Neighborhood(Seq(tokenIx)))
   }
 }
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
@@ -301,7 +301,7 @@ object ParseRerankerTraining {
   ): Unit = {
     val sentenceResultsMap = classifierResults.groupBy(_.labeledVectorPerParseFamily.sentence)
     for ((sentence, classifierResults) <- sentenceResultsMap) {
-      pw.write(s"\ns${sentence}\n")
+      pw.write(s"\n${sentence}\n")
       for (result <- classifierResults) {
         // Write Label Family out in the following format:
         //(<NodeIx>, <NodeTokenString>) -> (<ArcLabel>, (<ChildNodeIx>, <ChildNodeTokenString>)),

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
@@ -301,7 +301,7 @@ object ParseRerankerTraining {
   ): Unit = {
     val sentenceResultsMap = classifierResults.groupBy(_.labeledVectorPerParseFamily.sentence)
     for ((sentence, classifierResults) <- sentenceResultsMap) {
-      pw.write(s"\nsentence:${sentence}:\n")
+      pw.write(s"\ns${sentence}\n")
       for (result <- classifierResults) {
         // Write Label Family out in the following format:
         //(<NodeIx>, <NodeTokenString>) -> (<ArcLabel>, (<ChildNodeIx>, <ChildNodeTokenString>)),

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
@@ -74,7 +74,7 @@ object ParseRerankerTraining {
           "datastore location info to access Verbnet resources for the Verbnet tagger.")
       opt[String]('l', "classifier-output-log") valueName ("<string>") action
         { (x, c) => c.copy(classifierOutputLogPathOption = Some(x)) } text ("path of required " +
-          "output log file containing False Positives and True Negatives from the classifier on " +
+          "output log file containing False Positives and False Negatives from the classifier on " +
           "the test set")
     }
     val clArgs: PRTCommandLine =


### PR DESCRIPTION
@mhrmm : Could you take a look? Logs weirdness classifier's misclassified families, one per line along with corresponding feature vector, grouped by sentences, in this format:

```
False Positives:
<sentence>
<node> -> (<arcSymbol>, <childNode>), (<arcSymbol>, <childNode>)... \t <featureVector>
...

False Negatives:
<sentence>
<node> -> (<arcSymbol>, <childNode>), (<arcSymbol>, <childNode>)... \t <featureVector>
...

```

Sample:

```
False Positives:

What constitutes an adult ?
(1, What)  -> (DET, (4, adult)) [child1.alabel.DET -> 1.000 self.cpos.DET -> 1.000 child.cpos.NOUN -> 1.000 self.keyword.what -> 1.000 child1.direction.R -> 1.000 children.card.1 -> 1.000 child1.cpos.NOUN -> 1.000]

Where was Richard Nixon when Gerald Ford became president ?
(1, Where)  -> (ADVMOD, (8, became))    [child1.alabel.ADVMOD -> 1.000 self.keyword.where -> 1.000 self.cpos.ADV -> 1.000 child1.direction.R -> 1.000 children.card.1 -> 1.000 child1.cpos.VERB -> 1.000 child.cpos.VERB -> 1.000]
(10, ?)  -> (PUNCT, (8, became))        [child1.direction.L -> 1.000 children.card.1 -> 1.000 child1.alabel.PUNCT -> 1.000 self.cpos.. -> 1.000 child1.cpos.VERB -> 1.000 child.cpos.VERB -> 1.000]
...
```

* Renamed `TrainingData` to `LabeledFeatureVectors` since I found it confusing to call train and test data `TrainingData`.
* Added some case classes as support structures for some of the family related info instead of passing tuples around, which got really confusing especially after augmenting the feature vectors with associated information (sentence and family) in `LabeledFeatureVectorPerParseFamily `, to make it available post evaluation for printing diagnostics. 