### PR TITLE
Don't use JavaConversions.

### DIFF
--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/Verbnet.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/Verbnet.scala
@@ -5,7 +5,7 @@ import org.allenai.datastore._
 import edu.mit.jverbnet.data._
 import edu.mit.jverbnet.index._
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import java.net._
 
@@ -36,15 +36,11 @@ case class Verbnet(groupName: String, artifactName: String, version: Int) {
     val table = scala.collection.mutable.HashMap.empty[Symbol, Set[IVerbClass]]
     // Iterate through verb classes, and for each, extract the verb and
     // its synonyms. Populate synonym map.
-    val vList = index.iterator.toList
+    val vList = index.iterator.asScala
     for (vClass <- vList) {
-      for (classMember <- vClass.getMembers) {
+      for (classMember <- vClass.getMembers.asScala) {
         val member = Symbol(classMember.getName.trim)
-        if (!table.containsKey(member)) {
-          table.put(member, Set.empty[IVerbClass] + vClass)
-        } else {
-          table.update(member, table(member) + vClass)
-        }
+        table(member) = table.getOrElse(member, Set.empty) + vClass
       }
     }
     table.toMap
@@ -69,7 +65,7 @@ case class Verbnet(groupName: String, artifactName: String, version: Int) {
   def getVerbnetFrames(verb: String): Set[IFrame] = {
     // Get all classes
     val verbClasses = getVerbnetClasses(verb)
-    verbClasses flatMap { verbClass => verbClass.getFrames }
+    verbClasses flatMap { verbClass => verbClass.getFrames.asScala }
   }
 
   /* Returns the set of primary names for all frames within all classes


### PR DESCRIPTION
`JavaConversions` is bad news! Note that you were using `containsKey` and `put` - `java.util.Map` methods - on a `scala.collection.Map`, and mixing *those* with an `update` - a `scala.collection.Map` method!

This is why they should be avoided.