### PR TITLE
Port polyparser models to reming.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -189,6 +189,7 @@ object NlpstackBuild extends Build {
       libraryDependencies ++= Seq(
         factorie,
         scopt,
+        reming,
         datastore,
         jVerbnet
       )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,5 +29,7 @@ object Dependencies extends CoreDependencies {
 
   val jVerbnet = "edu.mit" % "jverbnet" % "1.2.0.1"
 
+  val reming = "com.github.jkinkead" %% "reming-json" % "0.0.9"
+
   val Overrides = Set("org.slf4j" % "log4j-over-slf4j" % "1.7.10")
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/BankerProtocol.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/BankerProtocol.scala
@@ -1,0 +1,59 @@
+package org.allenai.nlpstack.parse
+
+import org.allenai.common.json._
+import org.allenai.nlpstack.parse.poly.core.{ Sentence, Token }
+import org.allenai.nlpstack.parse.poly.fsm.TransitionConstraint
+import org.allenai.nlpstack.parse.poly.polyparser.{
+  ForbiddenArcLabel,
+  ForbiddenEdge,
+  PolytreeParse,
+  RequestedCpos,
+  RequestedArc
+}
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+/** spray-json protocol for objects used by the banker UI. This will help ease the migration to
+  * reming (or allow the banker UI to stay on spray-json).
+  * The banker UI uses TransitionConstraint and PolytreeParse in its models.
+  */
+object BankerProtocol {
+  // TransitionConstraint format.
+  implicit val forbiddenEdgeFormat =
+    jsonFormat2(ForbiddenEdge.apply).pack("constraintType" -> "forbiddenEdge")
+
+  implicit val forbiddenArcLabelFormat =
+    jsonFormat3(ForbiddenArcLabel.apply).pack("constraintType" -> "forbiddenArcLabel")
+
+  implicit val requestedArcFormat =
+    jsonFormat(RequestedArc.apply, "token1", "token2", "arcLabel").pack(
+      "constraintType" -> "requestedArc"
+    )
+
+  implicit val requestedCposFormat =
+    jsonFormat2(RequestedCpos.apply).pack("constraintType" -> "requestedCpos")
+
+  implicit object ParserConstraintFormat extends JsonFormat[TransitionConstraint] {
+    override def read(jsValue: JsValue): TransitionConstraint = {
+      jsValue.asJsObject.unpackWith[TransitionConstraint](
+        forbiddenEdgeFormat,
+        forbiddenArcLabelFormat,
+        requestedArcFormat,
+        requestedCposFormat
+      )
+    }
+
+    override def write(constraint: TransitionConstraint): JsValue = constraint match {
+      case forbiddenEdge: ForbiddenEdge => forbiddenEdge.toJson
+      case forbiddenArcLabel: ForbiddenArcLabel => forbiddenArcLabel.toJson
+      case requestedArc: RequestedArc => requestedArc.toJson
+      case requestedCpos: RequestedCpos => requestedCpos.toJson
+    }
+  }
+
+  // PolytreeParse
+  implicit val tokenFormat = jsonFormat2(Token.apply)
+  implicit val sentenceFormat = jsonFormat1(Sentence.apply)
+  implicit val polytreeParseFormat = jsonFormat4(PolytreeParse.apply)
+}

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/Sentence.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/Sentence.scala
@@ -3,7 +3,8 @@ package org.allenai.nlpstack.parse.poly.core
 import org.allenai.common.immutable.Interval
 import org.allenai.nlpstack.parse.poly.fsm.MarbleBlock
 import org.allenai.nlpstack.parse.poly.ml.FeatureVector
-import spray.json.DefaultJsonProtocol._
+
+import reming.DefaultJsonProtocol._
 
 import scala.collection.mutable.Stack
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/SentenceTransform.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/SentenceTransform.scala
@@ -12,7 +12,7 @@ trait SentenceTransform {
 }
 
 object SentenceTransform {
-  private implicit val factorySentenceTaggerFormat = jsonFormat0(() => FactorieSentenceTagger)
+  private implicit val factorieSentenceTaggerFormat = jsonFormat0(() => FactorieSentenceTagger)
   private implicit val stanfordSentenceTaggerFormat = jsonFormat0(() => StanfordSentenceTagger)
   private implicit val lexicalPropertiesTaggerFormat = jsonFormat0(() => LexicalPropertiesTagger)
   private implicit val brownClustersTaggerFormat = jsonFormat1(BrownClustersTagger.apply)

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/SentenceTransform.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/SentenceTransform.scala
@@ -5,58 +5,26 @@ import org.allenai.nlpstack.parse.poly.ml.{ BrownClusters, Verbnet }
 import org.allenai.nlpstack.postag._
 import org.allenai.nlpstack.lemmatize._
 
-import org.allenai.common.json._
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+import reming.DefaultJsonProtocol._
 
 trait SentenceTransform {
   def transform(sentence: Sentence): Sentence
 }
 
 object SentenceTransform {
+  private implicit val factorySentenceTaggerFormat = jsonFormat0(() => FactorieSentenceTagger)
+  private implicit val stanfordSentenceTaggerFormat = jsonFormat0(() => StanfordSentenceTagger)
+  private implicit val lexicalPropertiesTaggerFormat = jsonFormat0(() => LexicalPropertiesTagger)
+  private implicit val brownClustersTaggerFormat = jsonFormat1(BrownClustersTagger.apply)
+  private implicit val verbnetTaggerFormat = jsonFormat1(VerbnetTagger.apply)
 
-  /** Boilerplate code to serialize a SentenceTagger to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM SentenceTagger, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object SentenceTransformJsonFormat extends RootJsonFormat[SentenceTransform] {
-
-    implicit val brownClustersTaggerFormat =
-      jsonFormat1(BrownClustersTagger.apply).pack("type" -> "BrownClustersTagger")
-
-    implicit val verbnetTaggerFormat =
-      jsonFormat1(VerbnetTagger.apply).pack("type" -> "VerbnetTagger")
-
-    def write(sentenceTagger: SentenceTransform): JsValue = sentenceTagger match {
-      case FactorieSentenceTagger =>
-        JsString("FactorieSentenceTagger")
-      case StanfordSentenceTagger =>
-        JsString("StanfordSentenceTagger")
-      case LexicalPropertiesTagger =>
-        JsString("LexicalPropertiesTagger")
-      case brownClustersTagger: BrownClustersTagger =>
-        brownClustersTagger.toJson
-      case verbnetTagger: VerbnetTagger =>
-        verbnetTagger.toJson
-    }
-
-    def read(value: JsValue): SentenceTransform = value match {
-      case JsString(typeid) => typeid match {
-        case "FactorieSentenceTagger" => FactorieSentenceTagger
-        case "StanfordSentenceTagger" => StanfordSentenceTagger
-        case "LexicalPropertiesTagger" => LexicalPropertiesTagger
-        case x => deserializationError(s"Invalid identifier for TaskIdentifier: $x")
-      }
-      case jsObj: JsObject => jsObj.unpackWith(
-        brownClustersTaggerFormat,
-        verbnetTaggerFormat
-      )
-      case _ => deserializationError("Unexpected JsValue type. Must be JsString.")
-    }
-  }
+  implicit val sentenceTransformJsonFormat = parentFormat[SentenceTransform](
+    childFormat[FactorieSentenceTagger.type, SentenceTransform],
+    childFormat[StanfordSentenceTagger.type, SentenceTransform],
+    childFormat[LexicalPropertiesTagger.type, SentenceTransform],
+    childFormat[BrownClustersTagger, SentenceTransform],
+    childFormat[VerbnetTagger, SentenceTransform]
+  )
 }
 
 /** The FactorieSentenceTagger tags an input sentence with automatic part-of-speech tags

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/Token.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/Token.scala
@@ -1,6 +1,6 @@
 package org.allenai.nlpstack.parse.poly.core
 
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 /** A Token is the basic atom of a sentence.
   *

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/Util.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/core/Util.scala
@@ -1,25 +1,24 @@
 package org.allenai.nlpstack.parse.poly.core
 
+import org.allenai.common.Resource
+import reming.{ JsonFormat, JsonParser }
+
 import java.io.{ File, InputStream, PushbackInputStream }
 import java.net.URL
 import java.util.zip.GZIPInputStream
 
-import org.allenai.common.Resource._
-import spray.json._
-
-import scala.io.Source
+import scala.io.BufferedSource
 
 object Util {
-
-  def getJsValueFromFile(filename: String): JsValue = {
-    getJsValueFromUrl(new File(filename).toURI.toURL)
+  def readFromFile[T: JsonFormat](filename: String): T = {
+    readFromUrl(new File(filename).toURI.toURL)
   }
 
-  def getJsValueFromUrl(url: URL): JsValue = {
-    using(url.openStream()) { getJsValueFromStream }
+  def readFromUrl[T: JsonFormat](url: URL): T = {
+    Resource.using(url.openStream()) { readFromStream[T] }
   }
 
-  def getJsValueFromStream(stream: InputStream): JsValue = {
+  def readFromStream[T: JsonFormat](stream: InputStream): T = {
     val headerLength = 2
     val pbStream = new PushbackInputStream(stream, headerLength)
     val header = new Array[Byte](headerLength)
@@ -38,6 +37,6 @@ object Util {
         pbStream
       }
 
-    Source.fromInputStream(uncompressedStream).mkString.parseJson
+    JsonParser.read[T](new BufferedSource(uncompressedStream))
   }
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
@@ -1,7 +1,8 @@
 package org.allenai.nlpstack.parse.poly.decisiontree
 
-import spray.json._
 import scala.annotation.tailrec
+
+import reming.DefaultJsonProtocol._
 
 /** Immutable decision tree for integer-valued features and outcomes.
   *
@@ -129,17 +130,5 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
 }
 
 object DecisionTree {
-  // Override the Spray/JSON serialization for maps with integer keys, because these
-  // don't work out-of-the-box.
-  import spray.json.DefaultJsonProtocol.{ mapFormat => _, _ }
-  implicit val intMapFormat = new JsonFormat[Map[Int, Int]] {
-    override def write(map: Map[Int, Int]): JsValue = {
-      map.toSeq.toJson
-    }
-    override def read(json: JsValue): Map[Int, Int] = json match {
-      case value: JsArray => value.convertTo[Seq[(Int, Int)]].toMap
-      case _ => throw new DeserializationException("Expected JSArray for int map")
-    }
-  }
-  implicit val dtFormat = jsonFormat4(DecisionTree.apply)
+  implicit val decisionTreeFormat = jsonFormat4(DecisionTree.apply)
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/FeatureVector.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/FeatureVector.scala
@@ -1,27 +1,16 @@
 package org.allenai.nlpstack.parse.poly.decisiontree
 
-import org.allenai.common.json._
-
-import spray.json._
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 private object FeatureVector {
+  implicit val denseFormat = jsonFormat2(DenseVector.apply)
 
-  implicit val denseFormat = jsonFormat2(DenseVector.apply).pack("type" -> "dense")
+  implicit val sparseFormat = jsonFormat3(SparseVector.apply)
 
-  implicit val sparseFormat = jsonFormat3(SparseVector.apply).pack("type" -> "sparse")
-
-  implicit object FeatureVectorJsonFormat extends JsonFormat[FeatureVector] {
-
-    override def write(featureVector: FeatureVector): JsValue = featureVector match {
-      case dense: DenseVector => dense.toJson
-      case sparse: SparseVector => sparse.toJson
-    }
-
-    override def read(value: JsValue): FeatureVector = {
-      value.asJsObject.unpackWith[FeatureVector](denseFormat, sparseFormat)
-    }
-  }
+  implicit val featureVectorJsonFormat = parentFormat[FeatureVector](
+    childFormat[DenseVector, FeatureVector],
+    childFormat[SparseVector, FeatureVector]
+  )
 }
 
 /** A feature vector with integral features and outcome. */

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/FeatureVectorSource.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/FeatureVectorSource.scala
@@ -1,7 +1,8 @@
 package org.allenai.nlpstack.parse.poly.decisiontree
 
 import org.allenai.nlpstack.parse.poly.fsm.ClassificationTask
-import spray.json.DefaultJsonProtocol._
+
+import reming.DefaultJsonProtocol._
 
 trait FeatureVectorSource {
   def vectorIterator: Iterator[FeatureVector]

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
@@ -1,8 +1,7 @@
 package org.allenai.nlpstack.parse.poly.decisiontree
 
-import org.allenai.common.json._
-import spray.json._
-import spray.json.DefaultJsonProtocol._
+import reming.LazyFormat
+import reming.DefaultJsonProtocol._
 
 trait ProbabilisticClassifier {
 
@@ -29,33 +28,14 @@ trait ProbabilisticClassifier {
 
 object ProbabilisticClassifier {
 
-  /** Boilerplate code to serialize a ProbabilisticClassifier to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM ProbabilisticClassifier, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object ProbabilisticClassifierJsonFormat
-      extends RootJsonFormat[ProbabilisticClassifier] {
+  implicit object ProbabilisticClassifierFormat extends LazyFormat[ProbabilisticClassifier] {
+    private implicit val randomForestFormat = jsonFormat2(RandomForest.apply)
+    private implicit val oneVersusAllFormat = jsonFormat1(OneVersusAll.apply)
 
-    implicit val decisionTreeFormat = DecisionTree.dtFormat.pack("type" -> "DecisionTree")
-    implicit val randomForestFormat =
-      jsonFormat2(RandomForest.apply).pack(
-        "type" -> "RandomForest"
-      )
-    implicit val oneVersusAllFormat =
-      jsonFormat1(OneVersusAll.apply).pack("type" -> "OneVersusAll")
-
-    def write(classifier: ProbabilisticClassifier): JsValue = classifier match {
-      case decisionTree: DecisionTree => decisionTree.toJson
-      case randomForest: RandomForest => randomForest.toJson
-      case oneVersusAll: OneVersusAll => oneVersusAll.toJson
-      case x => deserializationError(s"Cannot serialize this classifier type: $x")
-    }
-
-    def read(value: JsValue): ProbabilisticClassifier = value.asJsObject.unpackWith(
-      decisionTreeFormat, randomForestFormat, oneVersusAllFormat
+    override val delegate = parentFormat[ProbabilisticClassifier](
+      childFormat[DecisionTree, ProbabilisticClassifier],
+      childFormat[RandomForest, ProbabilisticClassifier],
+      childFormat[OneVersusAll, ProbabilisticClassifier]
     )
   }
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
@@ -1,12 +1,14 @@
 package org.allenai.nlpstack.parse.poly.decisiontree
 
-import java.io.{ PrintWriter, File }
-
 import org.allenai.common.Resource
 import org.allenai.nlpstack.parse.poly.core.Util
 import org.allenai.nlpstack.parse.poly.fsm.{ TransitionClassifier, ClassificationTask }
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.CompactPrinter
+import reming.DefaultJsonProtocol._
+
+import java.io.{ BufferedWriter, File, FileWriter, PrintWriter }
+
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import scala.language.postfixOps
@@ -110,8 +112,8 @@ class RandomForestTrainer(validationPercentage: Double, numDecisionTrees: Int,
         case dt: DecisionTree =>
           val tempFile: File = File.createTempFile("temp.", ".dt")
           tempFile.deleteOnExit()
-          Resource.using(new PrintWriter(tempFile)) { writer =>
-            writer.println(dt.toJson.compactPrint)
+          Resource.using(new PrintWriter(new BufferedWriter(new FileWriter(tempFile)))) { writer =>
+            writer.println(CompactPrinter.printTo(writer, dt))
           }
           tempFile
       }
@@ -119,15 +121,7 @@ class RandomForestTrainer(validationPercentage: Double, numDecisionTrees: Int,
     val futureSubtreeFiles: Future[Seq[File]] = Future.sequence(tasks)
     val subtreeFiles = Await.result(futureSubtreeFiles, 30 days)
     val subtrees: Seq[DecisionTree] = subtreeFiles map {
-      case subtreeFile =>
-        Resource.using(subtreeFile.toURI.toURL.openStream()) { stream =>
-          val jsVal = Util.getJsValueFromStream(stream)
-          jsVal match {
-            case JsObject(_) => jsVal.convertTo[DecisionTree]
-            case _ => deserializationError("Unexpected JsValue type. Must be " +
-              "JsObject.")
-          }
-        }
+      case subtreeFile => Util.readFromUrl[DecisionTree](subtreeFile.toURI.toURL)
     }
     System.clearProperty("scala.concurrent.context.numThreads")
     RandomForest(data.allOutcomes, subtrees)

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/NbestCorpus.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/NbestCorpus.scala
@@ -1,8 +1,8 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
 import org.allenai.nlpstack.parse.poly.core.Util
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 /** A sequence of (scored) sculptures. */
 case class NbestList(scoredSculptures: Iterable[(Sculpture, Double)])
@@ -18,13 +18,5 @@ case class NbestCorpus(nbestLists: Iterable[NbestList])
 object NbestCorpus {
   implicit val jsFormat = jsonFormat1(NbestCorpus.apply)
 
-  def loadNbestCorpus(filename: String): NbestCorpus = {
-    val jsValue = Util.getJsValueFromFile(filename)
-    jsValue match {
-      case JsObject(values) =>
-      case _ => deserializationError("Unexpected JsValue type. Must be " +
-        "JsObject.")
-    }
-    jsValue.convertTo[NbestCorpus]
-  }
+  def loadNbestCorpus(filename: String): NbestCorpus = Util.readFromFile(filename)
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/Sculpture.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/Sculpture.scala
@@ -1,10 +1,8 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
-import org.allenai.common.json._
-
 import org.allenai.nlpstack.parse.poly.polyparser.{ PolytreeParse }
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 /** A Sculpture is a structured output corresponding to a final state of a finite-state
   * machine, whose goal is to transform an unstructured input (a MarbleBlock) into a
@@ -18,25 +16,6 @@ trait Sculpture {
 }
 
 object Sculpture {
-
-  /** Boilerplate code to serialize a Sculpture to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM ClassificationTask, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object SculptureJsonFormat extends RootJsonFormat[Sculpture] {
-    implicit val polytreeParseFormat =
-      jsonFormat4(PolytreeParse.apply).pack("type" -> "PolytreeParse")
-
-    def write(sculpture: Sculpture): JsValue = sculpture match {
-      case polytreeParse: PolytreeParse => polytreeParse.toJson
-    }
-
-    def read(value: JsValue): Sculpture = value.asJsObject.unpackWith(
-      polytreeParseFormat
-    )
-  }
-
+  private implicit val polytreeParseFormat = jsonFormat4(PolytreeParse.apply)
+  implicit val sculptureJsonFormat = parentFormat[Sculpture](childFormat[PolytreeParse, Sculpture])
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/State.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/State.scala
@@ -1,9 +1,8 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
-import org.allenai.common.json._
 import org.allenai.nlpstack.parse.poly.polyparser.TransitionParserState
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 /** A state of a finite-state machine. */
 trait State {
@@ -12,19 +11,8 @@ trait State {
 }
 
 object State {
-  implicit object StateJsonFormat extends RootJsonFormat[State] {
-    implicit val transitionParserStateFormat =
-      jsonFormat8(TransitionParserState.apply).pack("type" -> "TransitionParserState")
-
-    def write(state: State): JsValue = state match {
-      case tpState: TransitionParserState => tpState.toJson
-      case x => deserializationError(s"Cannot serialize this state type: $x")
-    }
-
-    def read(value: JsValue): State = value.asJsObject.unpackWith(
-      transitionParserStateFormat
-    )
-  }
+  private implicit val transitionParserStateFormat = jsonFormat8(TransitionParserState.apply)
+  implicit val stateJsonFormat = parentFormat[State](childFormat[TransitionParserState, State])
 }
 
 /** A StateCost maps a state to a cost. */

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/StateFeature.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/StateFeature.scala
@@ -2,63 +2,30 @@ package org.allenai.nlpstack.parse.poly.fsm
 
 import org.allenai.nlpstack.parse.poly.ml.FeatureVector
 import org.allenai.nlpstack.parse.poly.polyparser._
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.LazyFormat
+import reming.DefaultJsonProtocol._
 
 /** A StateFeature computes a feature vector corresponding to a given parser state. */
 abstract class StateFeature extends (State => FeatureVector)
 
 object StateFeature {
+  private implicit val previousLinkDirectionFormat = jsonFormat0(() => PreviousLinkDirection)
+  private implicit val tokenTransformFeatureFormat = jsonFormat2(TokenTransformFeature.apply)
+  private implicit val offlineTokenFeatureFormat = jsonFormat2(OfflineTokenFeature.apply)
+  private implicit val tokenCardinalityFeatureFormat = jsonFormat1(TokenCardinalityFeature.apply)
 
-  /** Boilerplate code to serialize a TransitionParserFeature to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM TransitionParserFeature, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object StateFeatureJsonFormat
-      extends RootJsonFormat[StateFeature] {
+  implicit object StateFeatureJsonFormat extends LazyFormat[StateFeature] {
+    private implicit val featureUnionFormat = jsonFormat1(FeatureUnion.apply)
 
-    def write(feature: StateFeature): JsValue = feature match {
-      case PreviousLinkDirection => JsString("PreviousLinkDirection")
-      case ttFeature: TokenTransformFeature =>
-        JsObject(tokenTransformFeatureFormat.write(ttFeature).asJsObject.fields +
-          ("type" -> JsString("TokenTransformFeature")))
-      case tsFeature: OfflineTokenFeature =>
-        JsObject(offlineTokenFeatureFormat.write(tsFeature).asJsObject.fields +
-          ("type" -> JsString("OfflineTokenFeature")))
-      case tcFeature: TokenCardinalityFeature =>
-        JsObject(tokenCardinalityFeatureFormat.write(tcFeature).asJsObject.fields +
-          ("type" -> JsString("TokenCardinalityFeature")))
-      case featureUnion: FeatureUnion =>
-        JsObject(featureUnionFormat.write(featureUnion).asJsObject.fields +
-          ("type" -> JsString("FeatureUnion")))
-    }
-
-    def read(value: JsValue): StateFeature = value match {
-      case JsString(typeid) => typeid match {
-        case "PreviousLinkDirection" => PreviousLinkDirection
-        case x => deserializationError(s"Invalid identifier for Transition: $x")
-      }
-      case JsObject(values) => values("type") match {
-        case JsString("TokenTransformFeature") => tokenTransformFeatureFormat.read(value)
-        case JsString("OfflineTokenFeature") => offlineTokenFeatureFormat.read(value)
-        case JsString("TokenCardinalityFeature") => tokenCardinalityFeatureFormat.read(value)
-        case JsString("FeatureUnion") => featureUnionFormat.read(value)
-        case x => deserializationError(s"Invalid identifier for TransitionParserFeature: $x")
-      }
-      case _ => deserializationError("Unexpected JsValue type. Must be JsObject.")
-    }
+    override val delegate = parentFormat[StateFeature](
+      childFormat[PreviousLinkDirection.type, StateFeature],
+      childFormat[TokenTransformFeature, StateFeature],
+      childFormat[OfflineTokenFeature, StateFeature],
+      childFormat[TokenCardinalityFeature, StateFeature],
+      childFormat[FeatureUnion, StateFeature]
+    )
   }
-
-  val tokenTransformFeatureFormat: RootJsonFormat[TokenTransformFeature] =
-    jsonFormat2(TokenTransformFeature.apply)
-  val offlineTokenFeatureFormat: RootJsonFormat[OfflineTokenFeature] =
-    jsonFormat2(OfflineTokenFeature.apply)
-  val tokenCardinalityFeatureFormat: RootJsonFormat[TokenCardinalityFeature] =
-    jsonFormat1(TokenCardinalityFeature.apply)
-  val featureUnionFormat: RootJsonFormat[FeatureUnion] = jsonFormat1(FeatureUnion.apply)
 }
 
 /** A FeatureUnion simply merges the output of a list of features.

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionClassifier.scala
@@ -1,9 +1,8 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
-import org.allenai.common.json._
 import org.allenai.nlpstack.parse.poly.ml.FeatureVector
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 /** A TransitionClassifier maps Transitions to probabilities. */
 abstract class TransitionClassifier {
@@ -26,31 +25,10 @@ abstract class TransitionClassifier {
 
 /** Companion class for serializing TransitionClassifier instances. */
 object TransitionClassifier {
+  private implicit val embeddedClassifierFormat = jsonFormat4(EmbeddedClassifier.apply)
 
-  /** Boilerplate code to serialize a TransitionClassifier to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM TransitionClassifier, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object TransitionClassifierJsonFormat extends RootJsonFormat[TransitionClassifier] {
-    implicit val embeddedClassifierFormat =
-      jsonFormat4(EmbeddedClassifier.apply).pack("type" -> "EmbeddedClassifier")
-    //implicit val adaptiveDecisionTreeClassifierFormat =
-    //  jsonFormat4(AdaptiveDecisionTreeClassifier.apply).pack(
-    //    "type" -> "AdaptiveDecisionTreeClassifier")
-
-    def write(classifier: TransitionClassifier): JsValue = classifier match {
-      case embClassifier: EmbeddedClassifier => embClassifier.toJson
-      //case adtClassifier: AdaptiveDecisionTreeClassifier => adtClassifier.toJson
-      case x => deserializationError(s"Cannot serialize this classifier type: $x")
-    }
-
-    def read(value: JsValue): TransitionClassifier = value.asJsObject.unpackWith(
-      embeddedClassifierFormat
-    )
-    //adaptiveDecisionTreeClassifierFormat)
-  }
+  implicit val transitionClassifierJsonFormat = parentFormat[TransitionClassifier](
+    childFormat[EmbeddedClassifier, TransitionClassifier]
+  )
 }
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionConstraint.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionConstraint.scala
@@ -1,14 +1,12 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
-import org.allenai.common.json._
 import org.allenai.nlpstack.parse.poly.polyparser.{
   RequestedCpos,
   RequestedArc,
   ForbiddenArcLabel,
   ForbiddenEdge
 }
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+import reming.DefaultJsonProtocol._
 
 /** A TransitionConstraint returns true if a given transition is illegal to
   * apply in a given state.
@@ -16,37 +14,16 @@ import spray.json._
 trait TransitionConstraint
 
 object TransitionConstraint {
-  implicit val forbiddenEdgeFormat =
-    jsonFormat2(ForbiddenEdge.apply).pack("constraintType" -> "forbiddenEdge")
-
-  implicit val forbiddenArcLabelFormat =
-    jsonFormat3(ForbiddenArcLabel.apply).pack("constraintType" -> "forbiddenArcLabel")
-
-  implicit val requestedArcFormat =
-    jsonFormat(RequestedArc.apply, "token1", "token2", "arcLabel").pack(
-      "constraintType" -> "requestedArc"
-    )
-
-  implicit val requestedCposFormat =
-    jsonFormat2(RequestedCpos.apply).pack("constraintType" -> "requestedCpos")
-
-  implicit object ParserConstraintFormat extends JsonFormat[TransitionConstraint] {
-    override def read(jsValue: JsValue): TransitionConstraint = {
-      jsValue.asJsObject.unpackWith[TransitionConstraint](
-        forbiddenEdgeFormat,
-        forbiddenArcLabelFormat,
-        requestedArcFormat,
-        requestedCposFormat
-      )
-    }
-
-    override def write(constraint: TransitionConstraint): JsValue = constraint match {
-      case forbiddenEdge: ForbiddenEdge => forbiddenEdge.toJson
-      case forbiddenArcLabel: ForbiddenArcLabel => forbiddenArcLabel.toJson
-      case requestedArc: RequestedArc => requestedArc.toJson
-      case requestedCpos: RequestedCpos => requestedCpos.toJson
-    }
-  }
+  private implicit val forbiddenEdgeFormat = jsonFormat2(ForbiddenEdge.apply)
+  private implicit val forbiddenArcLabelFormat = jsonFormat3(ForbiddenArcLabel.apply)
+  private implicit val requestedArcFormat = jsonFormat3(RequestedArc.apply)
+  private implicit val requestedCposFormat = jsonFormat2(RequestedCpos.apply)
+  implicit val parserConstraintFormat = parentFormat[TransitionConstraint](
+    childFormat[ForbiddenEdge, TransitionConstraint],
+    childFormat[ForbiddenArcLabel, TransitionConstraint],
+    childFormat[RequestedArc, TransitionConstraint],
+    childFormat[RequestedCpos, TransitionConstraint]
+  )
 }
 
 /** A ConstraintInterpretation tells you whether a transition is inapplicable in a given state.

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionSystem.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionSystem.scala
@@ -1,10 +1,9 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
-import org.allenai.common.json._
 import org.allenai.nlpstack.parse.poly.ml.FeatureVector
 import org.allenai.nlpstack.parse.poly.polyparser.{ ArcHybridTransitionSystemFactory, ArcEagerTransitionSystemFactory, ArcHybridTransitionSystem, ArcEagerTransitionSystem }
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 trait TransitionSystem {
   val taskIdentifier: TaskIdentifier
@@ -31,32 +30,10 @@ trait TransitionSystemFactory {
 }
 
 object TransitionSystemFactory {
-
-  implicit object TransitionSystemFactoryJsonFormat
-      extends RootJsonFormat[TransitionSystemFactory] {
-
-    implicit val arcEagerFormat =
-      jsonFormat1(ArcEagerTransitionSystemFactory.apply).pack(
-        "type" -> "ArcEagerTransitionSystemFactory"
-      )
-    implicit val arcHybridFormat =
-      jsonFormat1(ArcHybridTransitionSystemFactory.apply).pack(
-        "type" -> "ArcHybridTransitionSystemFactory"
-      )
-
-    def write(transitionSystemFactory: TransitionSystemFactory): JsValue =
-      transitionSystemFactory match {
-        case aeSys: ArcEagerTransitionSystemFactory => aeSys.toJson
-        case ahSys: ArcHybridTransitionSystemFactory => ahSys.toJson
-        case x => deserializationError(s"Cannot serialize this state type: $x")
-      }
-
-    def read(value: JsValue): TransitionSystemFactory = value match {
-      case JsString(typeid) => typeid match {
-        case x => deserializationError(s"Invalid identifier for TaskIdentifier: $x")
-      }
-      case jsObj: JsObject => jsObj.unpackWith(arcEagerFormat, arcHybridFormat)
-      case _ => deserializationError("Unexpected JsValue type.")
-    }
-  }
+  private implicit val arcHybridFormat = jsonFormat1(ArcHybridTransitionSystemFactory.apply)
+  private implicit val arcEagerFormat = jsonFormat1(ArcEagerTransitionSystemFactory.apply)
+  implicit val transitionSystemFactoryJsonFormat = parentFormat[TransitionSystemFactory](
+    childFormat[ArcHybridTransitionSystemFactory, TransitionSystemFactory],
+    childFormat[ArcEagerTransitionSystemFactory, TransitionSystemFactory]
+  )
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/Walk.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/Walk.scala
@@ -1,6 +1,6 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 /** A WalkStep is a single step in an FSM walk.
   *

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/BrownClusters.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/BrownClusters.scala
@@ -1,6 +1,7 @@
 package org.allenai.nlpstack.parse.poly.ml
 
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
+
 import scala.io.Source
 
 case class BrownClusters(clusters: Iterable[(Symbol, Seq[Int])]) {

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/FeatureVector.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/FeatureVector.scala
@@ -1,6 +1,6 @@
 package org.allenai.nlpstack.parse.poly.ml
 
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 /** The name of a feature, represented as a list of Symbols.
   *

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/LinearModel.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/LinearModel.scala
@@ -1,8 +1,8 @@
 package org.allenai.nlpstack.parse.poly.ml
 
 import org.allenai.nlpstack.parse.poly.core.Util
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 /** A weighted linear combination of features.
   *
@@ -39,13 +39,5 @@ case class LinearModel(val coefficients: Seq[(FeatureName, Double)]) {
 object LinearModel {
   implicit val jsFormat = jsonFormat1(LinearModel.apply)
 
-  def loadLinearModel(filename: String): LinearModel = {
-    val jsValue = Util.getJsValueFromFile(filename)
-    jsValue match {
-      case JsObject(values) =>
-      case _ => deserializationError("Unexpected JsValue type. Must be " +
-        "JsObject.")
-    }
-    jsValue.convertTo[LinearModel]
-  }
+  def loadLinearModel(filename: String): LinearModel = Util.readFromFile[LinearModel](filename)
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/TrainingData.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/TrainingData.scala
@@ -1,6 +1,6 @@
 package org.allenai.nlpstack.parse.poly.ml
 
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 /** Maps feature names to integers. Useful for serializing TrainingData instances for
   * consumption by command-line machine learning tools.

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/Verbnet.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/Verbnet.scala
@@ -4,13 +4,11 @@ import org.allenai.datastore._
 
 import edu.mit.jverbnet.data._
 import edu.mit.jverbnet.index._
-
-import scala.collection.JavaConverters._
+import reming.DefaultJsonProtocol._
 
 import java.net._
 
-import spray.json._
-import DefaultJsonProtocol._
+import scala.collection.JavaConverters._
 
 /** A class that uses JVerbnet, a 3rd party Wrapper library for Verbnet data
   * (http://projects.csail.mit.edu/jverbnet/),  to quickly look up various vernbet

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
@@ -8,7 +8,9 @@ import org.allenai.nlpstack.parse.poly.decisiontree.{
   ProbabilisticClassifier
 }
 import org.allenai.nlpstack.parse.poly.fsm.SimpleTask
-import spray.json.DefaultJsonProtocol._
+
+import reming.DefaultJsonProtocol._
+
 import scala.collection.immutable.HashSet
 
 /** A WrapperClassifier wraps a ProbabilisticClassifier (which uses integer-based feature

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/NbestParser.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/NbestParser.scala
@@ -4,7 +4,6 @@ import java.io.{ File, PrintWriter }
 
 import org.allenai.nlpstack.parse.poly.core.{ Sentence, SentenceSource }
 import org.allenai.nlpstack.parse.poly.fsm._
-import spray.json._
 
 import scopt.OptionParser
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/Neighborhood.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/Neighborhood.scala
@@ -1,6 +1,6 @@
 package org.allenai.nlpstack.parse.poly.polyparser
 
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 /** A Neighborhood is a sequence of token indices, generally referring to a parse tree.
   *

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ParsePool.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ParsePool.scala
@@ -7,8 +7,9 @@ import org.allenai.nlpstack.parse.poly.fsm.NbestList
 
 import scala.io.Source
 import scala.util.Random
-import spray.json._
-import spray.json.DefaultJsonProtocol._
+
+import reming.{ CompactPrinter, JsonParser }
+import reming.DefaultJsonProtocol._
 
 /** A ParsePool is a collection of parse candidates for the same input sentence.
   *
@@ -49,7 +50,7 @@ case class FileBasedParsePoolSource(filename: String) extends ParsePoolSource {
   override def poolIterator: Iterator[ParsePool] = {
     val lines: Iterator[String] = Source.fromFile(filename).getLines
     lines map { line =>
-      line.parseJson.convertTo[ParsePool]
+      JsonParser.read[ParsePool](line)
     }
   }
 }
@@ -59,7 +60,7 @@ object FileBasedParsePoolSource {
   def writePools(pools: Iterator[ParsePool], filename: String) {
     Resource.using(new PrintWriter(new File(filename))) { writer =>
       for (pool <- pools) {
-        writer.println(pool.toJson.compactPrint)
+        CompactPrinter.printTo(writer, pool)
       }
     }
   }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ParserConfiguration.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ParserConfiguration.scala
@@ -4,10 +4,8 @@ import java.io.{ PrintWriter, File, InputStream }
 import java.net.URL
 
 import org.allenai.common.Resource._
-import spray.json.DefaultJsonProtocol._
 import org.allenai.nlpstack.parse.poly.fsm.{ StateCostFunctionFactory, RerankingFunction, StateCostFunction }
-import org.allenai.nlpstack.parse.poly.core.Util
-import spray.json._
+import reming.DefaultJsonProtocol._
 
 /** Contains the key components of a parser (for serialization purposes).
   *
@@ -22,5 +20,5 @@ case class ParserConfiguration(
 )
 
 object ParserConfiguration {
-  implicit val jsFormat = jsonFormat3(ParserConfiguration.apply)
+  implicit val parserConfigurationFormat = jsonFormat3(ParserConfiguration.apply)
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
@@ -1,17 +1,19 @@
 package org.allenai.nlpstack.parse.poly.polyparser
 
-import java.io.{ File, PrintWriter }
+import org.allenai.nlpstack.core.PostaggedToken
+import org.allenai.nlpstack.core.{ Token => NLPStackToken }
+import org.allenai.nlpstack.core.Tokenizer
 import org.allenai.nlpstack.parse.poly.core._
 import org.allenai.nlpstack.parse.poly.fsm.{ Sculpture, MarbleBlock }
+import org.allenai.nlpstack.postag.defaultPostagger
+
+import reming.DefaultJsonProtocol._
+
+import java.io.{ File, PrintWriter }
 
 import scala.annotation.tailrec
 import scala.compat.Platform
 import scala.io.Source
-import spray.json.DefaultJsonProtocol._
-import org.allenai.nlpstack.core.PostaggedToken
-import org.allenai.nlpstack.core.{ Token => NLPStackToken }
-import org.allenai.nlpstack.core.Tokenizer
-import org.allenai.nlpstack.postag.defaultPostagger
 
 /** A PolytreeParse is a polytree-structured dependency parse. A polytree is a directed graph
   * whose undirected structure is a tree. The nodes of this graph will correspond to an indexed

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/StateRef.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/StateRef.scala
@@ -1,7 +1,6 @@
 package org.allenai.nlpstack.parse.poly.polyparser
 
-import spray.json._
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 /** A StateRef allows you to figure out the token that corresponds to a particular aspect of a
   * TransitionParserState.
@@ -24,156 +23,56 @@ sealed abstract class StateRef
 }
 
 object StateRef {
+  private implicit val lastRefFormat = jsonFormat0(() => LastRef)
+  private implicit val firstRefFormat = jsonFormat0(() => FirstRef)
+  private implicit val previousLinkCrumbRefFormat = jsonFormat0(() => PreviousLinkCrumbRef)
+  private implicit val previousLinkCrumbGretelRefFormat =
+    jsonFormat0(() => PreviousLinkCrumbGretelRef)
+  private implicit val previousLinkGretelRefFormat = jsonFormat0(() => PreviousLinkGretelRef)
+  private implicit val previousLinkGrandgretelRefFormat =
+    jsonFormat0(() => PreviousLinkGrandgretelRef)
+  private implicit val stackRefFormat = jsonFormat1(StackRef.apply)
+  private implicit val bufferRefFormat = jsonFormat1(BufferRef.apply)
+  private implicit val breadcrumbRefFormat = jsonFormat1(BreadcrumbRef.apply)
+  private implicit val stackChildrenRefFormat = jsonFormat1(StackChildrenRef.apply)
+  private implicit val stackChildRefFormat = jsonFormat2(StackChildRef.apply)
+  private implicit val bufferChildrenRefFormat = jsonFormat1(BufferChildrenRef.apply)
+  private implicit val bufferChildRefFormat = jsonFormat2(BufferChildRef.apply)
+  private implicit val stackParentsRefFormat = jsonFormat1(StackParentsRef.apply)
+  private implicit val stackParentRefFormat = jsonFormat2(StackParentRef.apply)
+  private implicit val bufferParentsRefFormat = jsonFormat1(BufferParentsRef.apply)
+  private implicit val bufferParentRefFormat = jsonFormat2(BufferParentRef.apply)
+  private implicit val stackGretelsRefFormat = jsonFormat1(StackGretelsRef.apply)
+  private implicit val stackLeftGretelsRefFormat = jsonFormat1(StackLeftGretelsRef.apply)
+  private implicit val stackRightGretelsRefFormat = jsonFormat1(StackRightGretelsRef.apply)
+  private implicit val bufferGretelsRefFormat = jsonFormat1(BufferGretelsRef.apply)
+  private implicit val bufferLeftGretelsRefFormat = jsonFormat1(BufferLeftGretelsRef.apply)
+  private implicit val bufferRightGretelsRefFormat = jsonFormat1(BufferRightGretelsRef.apply)
 
-  /** Boilerplate code to serialize a StateRef to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM StateRef, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object StateRefJsonFormat extends RootJsonFormat[StateRef] {
-    def write(stateRef: StateRef): JsValue = stateRef match {
-      case LastRef => JsString("LastRef")
-      case FirstRef => JsString("FirstRef")
-      case PreviousLinkCrumbRef => JsString("PreviousLinkCrumbRef")
-      case PreviousLinkGretelRef => JsString("PreviousLinkGretelRef")
-      case PreviousLinkCrumbGretelRef => JsString("PreviousLinkCrumbGretelRef")
-      case PreviousLinkGrandgretelRef => JsString("PreviousLinkGrandgretelRef")
-      case stackRef: StackRef => {
-        JsObject(stackRefFormat.write(stackRef).asJsObject.fields +
-          ("type" -> JsString("StackRef")))
-      }
-      case bufferRef: BufferRef => {
-        JsObject(bufferRefFormat.write(bufferRef).asJsObject.fields +
-          ("type" -> JsString("BufferRef")))
-      }
-      case breadcrumbRef: BreadcrumbRef => {
-        JsObject(breadcrumbRefFormat.write(breadcrumbRef).asJsObject.fields +
-          ("type" -> JsString("BreadcrumbRef")))
-      }
-      case stackChildrenRef: StackChildrenRef => {
-        JsObject(stackChildrenRefFormat.write(stackChildrenRef).asJsObject.fields +
-          ("type" -> JsString("StackChildrenRef")))
-      }
-      case stackChildRef: StackChildRef => {
-        JsObject(stackChildRefFormat.write(stackChildRef).asJsObject.fields +
-          ("type" -> JsString("StackChildRef")))
-      }
-      case bufferChildrenRef: BufferChildrenRef => {
-        JsObject(bufferChildrenRefFormat.write(bufferChildrenRef).asJsObject.fields +
-          ("type" -> JsString("BufferChildrenRef")))
-      }
-      case bufferChildRef: BufferChildRef => {
-        JsObject(bufferChildRefFormat.write(bufferChildRef).asJsObject.fields +
-          ("type" -> JsString("BufferChildRef")))
-      }
-      case stackParentsRef: StackParentsRef => {
-        JsObject(stackParentsRefFormat.write(stackParentsRef).asJsObject.fields +
-          ("type" -> JsString("StackParentsRef")))
-      }
-      case stackParentRef: StackParentRef => {
-        JsObject(stackParentRefFormat.write(stackParentRef).asJsObject.fields +
-          ("type" -> JsString("StackParentRef")))
-      }
-      case bufferParentsRef: BufferParentsRef => {
-        JsObject(bufferParentsRefFormat.write(bufferParentsRef).asJsObject.fields +
-          ("type" -> JsString("BufferParentsRef")))
-      }
-      case bufferParentRef: BufferParentRef => {
-        JsObject(bufferParentRefFormat.write(bufferParentRef).asJsObject.fields +
-          ("type" -> JsString("BufferParentRef")))
-      }
-      case stackGretelsRef: StackGretelsRef => {
-        JsObject(stackGretelsRefFormat.write(stackGretelsRef).asJsObject.fields +
-          ("type" -> JsString("StackGretelsRef")))
-      }
-      case stackLeftGretelsRef: StackLeftGretelsRef => {
-        JsObject(stackLeftGretelsRefFormat.write(stackLeftGretelsRef).asJsObject.fields +
-          ("type" -> JsString("StackLeftGretelsRef")))
-      }
-      case stackRightGretelsRef: StackRightGretelsRef => {
-        JsObject(stackRightGretelsRefFormat.write(stackRightGretelsRef).asJsObject.fields +
-          ("type" -> JsString("StackRightGretelsRef")))
-      }
-      case bufferGretelsRef: BufferGretelsRef => {
-        JsObject(bufferGretelsRefFormat.write(bufferGretelsRef).asJsObject.fields +
-          ("type" -> JsString("BufferGretelsRef")))
-      }
-      case bufferLeftGretelsRef: BufferLeftGretelsRef => {
-        JsObject(bufferLeftGretelsRefFormat.write(bufferLeftGretelsRef).asJsObject.fields +
-          ("type" -> JsString("BufferLeftGretelsRef")))
-      }
-      case bufferRightGretelsRef: BufferRightGretelsRef => {
-        JsObject(bufferRightGretelsRefFormat.write(bufferRightGretelsRef).asJsObject.fields +
-          ("type" -> JsString("BufferRightGretelsRef")))
-      }
-    }
-
-    def read(value: JsValue): StateRef = value match {
-      case JsString(typeid) => typeid match {
-        case "LastRef" => LastRef
-        case "FirstRef" => FirstRef
-        case "PreviousLinkCrumbRef" => PreviousLinkCrumbRef
-        case "PreviousLinkGretelRef" => PreviousLinkGretelRef
-        case "PreviousLinkCrumbGretelRef" => PreviousLinkCrumbGretelRef
-        case "PreviousLinkGrandgretelRef" => PreviousLinkGrandgretelRef
-      }
-      case JsObject(values) => values("type") match {
-        case JsString("StackRef") => stackRefFormat.read(value)
-        case JsString("BufferRef") => bufferRefFormat.read(value)
-        case JsString("BreadcrumbRef") => breadcrumbRefFormat.read(value)
-        case JsString("StackChildrenRef") => stackChildrenRefFormat.read(value)
-        case JsString("StackChildRef") => stackChildRefFormat.read(value)
-        case JsString("BufferChildrenRef") => bufferChildrenRefFormat.read(value)
-        case JsString("BufferChildRef") => bufferChildRefFormat.read(value)
-        case JsString("StackParentsRef") => stackParentsRefFormat.read(value)
-        case JsString("StackParentRef") => stackParentRefFormat.read(value)
-        case JsString("BufferParentsRef") => bufferParentsRefFormat.read(value)
-        case JsString("BufferParentRef") => bufferParentRefFormat.read(value)
-
-        case JsString("StackGretelsRef") => stackGretelsRefFormat.read(value)
-        case JsString("StackLeftGretelsRef") => stackLeftGretelsRefFormat.read(value)
-        case JsString("StackRightGretelsRef") => stackRightGretelsRefFormat.read(value)
-        case JsString("BufferGretelsRef") => bufferGretelsRefFormat.read(value)
-        case JsString("BufferLeftGretelsRef") => bufferLeftGretelsRefFormat.read(value)
-        case JsString("BufferRightGretelsRef") => bufferRightGretelsRefFormat.read(value)
-        case x => deserializationError(s"Invalid identifier for StateRef: $x")
-      }
-      case _ => deserializationError("Unexpected JsValue type. Must be JsString or JsObject.")
-    }
-  }
-
-  val stackRefFormat: RootJsonFormat[StackRef] = jsonFormat1(StackRef.apply)
-  val bufferRefFormat: RootJsonFormat[BufferRef] = jsonFormat1(BufferRef.apply)
-  val breadcrumbRefFormat: RootJsonFormat[BreadcrumbRef] = jsonFormat1(BreadcrumbRef.apply)
-  val stackChildrenRefFormat: RootJsonFormat[StackChildrenRef] =
-    jsonFormat1(StackChildrenRef.apply)
-  val stackChildRefFormat: RootJsonFormat[StackChildRef] =
-    jsonFormat2(StackChildRef.apply)
-  val bufferChildrenRefFormat: RootJsonFormat[BufferChildrenRef] =
-    jsonFormat1(BufferChildrenRef.apply)
-  val bufferChildRefFormat: RootJsonFormat[BufferChildRef] =
-    jsonFormat2(BufferChildRef.apply)
-  val stackParentsRefFormat: RootJsonFormat[StackParentsRef] =
-    jsonFormat1(StackParentsRef.apply)
-  val stackParentRefFormat: RootJsonFormat[StackParentRef] =
-    jsonFormat2(StackParentRef.apply)
-  val bufferParentsRefFormat: RootJsonFormat[BufferParentsRef] =
-    jsonFormat1(BufferParentsRef.apply)
-  val bufferParentRefFormat: RootJsonFormat[BufferParentRef] =
-    jsonFormat2(BufferParentRef.apply)
-  val stackGretelsRefFormat: RootJsonFormat[StackGretelsRef] = jsonFormat1(StackGretelsRef.apply)
-  val stackLeftGretelsRefFormat: RootJsonFormat[StackLeftGretelsRef] =
-    jsonFormat1(StackLeftGretelsRef.apply)
-  val stackRightGretelsRefFormat: RootJsonFormat[StackRightGretelsRef] =
-    jsonFormat1(StackRightGretelsRef.apply)
-  val bufferGretelsRefFormat: RootJsonFormat[BufferGretelsRef] =
-    jsonFormat1(BufferGretelsRef.apply)
-  val bufferLeftGretelsRefFormat: RootJsonFormat[BufferLeftGretelsRef] =
-    jsonFormat1(BufferLeftGretelsRef.apply)
-  val bufferRightGretelsRefFormat: RootJsonFormat[BufferRightGretelsRef] =
-    jsonFormat1(BufferRightGretelsRef.apply)
+  implicit val stateRefJsonFormat = parentFormat[StateRef](
+    childFormat[LastRef.type, StateRef],
+    childFormat[FirstRef.type, StateRef],
+    childFormat[PreviousLinkCrumbRef.type, StateRef],
+    childFormat[PreviousLinkGretelRef.type, StateRef],
+    childFormat[PreviousLinkCrumbGretelRef.type, StateRef],
+    childFormat[PreviousLinkGrandgretelRef.type, StateRef],
+    childFormat[StackRef, StateRef],
+    childFormat[BufferRef, StateRef],
+    childFormat[BreadcrumbRef, StateRef],
+    childFormat[StackChildrenRef, StateRef],
+    childFormat[StackChildRef, StateRef],
+    childFormat[BufferChildrenRef, StateRef],
+    childFormat[BufferChildRef, StateRef],
+    childFormat[StackParentsRef, StateRef],
+    childFormat[BufferParentsRef, StateRef],
+    childFormat[BufferParentRef, StateRef],
+    childFormat[StackGretelsRef, StateRef],
+    childFormat[StackLeftGretelsRef, StateRef],
+    childFormat[StackRightGretelsRef, StateRef],
+    childFormat[BufferGretelsRef, StateRef],
+    childFormat[BufferLeftGretelsRef, StateRef],
+    childFormat[BufferRightGretelsRef, StateRef]
+  )
 }
 
 /** A StackRef is a StateRef (see above) whose apply operation returns the `index`th element of

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/TokenTransform.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/TokenTransform.scala
@@ -1,9 +1,6 @@
 package org.allenai.nlpstack.parse.poly.polyparser
 
-import org.allenai.common.json._
-
-import spray.json._
-import spray.json.DefaultJsonProtocol._
+import reming.DefaultJsonProtocol._
 
 /** A TokenTransform is a function that maps a token to a set of symbols.
   *
@@ -26,73 +23,29 @@ sealed abstract class TokenTransform
 }
 
 object TokenTransform {
+  private implicit val wordTransformFormat = jsonFormat0(() => WordTransform)
+  private implicit val breadcrumbAssignedFormat = jsonFormat0(() => BreadcrumbAssigned)
+  private implicit val breadcrumbArcFormat = jsonFormat0(() => BreadcrumbArc)
+  private implicit val isBrackedTransformFormat = jsonFormat0(() => IsBracketedTransform)
+  private implicit val tokenPropertyTransformFormat = jsonFormat1(TokenPropertyTransform.apply)
+  private implicit val numChildrenToTheLeftFormat = jsonFormat1(NumChildrenToTheLeft.apply)
+  private implicit val numChildrenToTheRightFormat = jsonFormat1(NumChildrenToTheRight.apply)
+  private implicit val keywordTransformFormat = jsonFormat1(KeywordTransform.apply)
+  private implicit val suffixTransformFormat = jsonFormat1(SuffixTransform.apply)
+  private implicit val prefixTransformFormat = jsonFormat1(PrefixTransform.apply)
 
-  /** Boilerplate code to serialize a TokenTransform to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM TokenTransform, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object TokenTransformJsonFormat extends RootJsonFormat[TokenTransform] {
-
-    implicit val tokenPropertyTransformFormat =
-      jsonFormat1(TokenPropertyTransform.apply).pack("type" -> "TokenPropertyTransform")
-
-    //implicit val lookAheadTransformFormat =
-    //  jsonFormat1(LookAheadTransform.apply).pack("type" -> "LookAheadTransform")
-
-    //implicit val lookBehindTransformFormat =
-    //  jsonFormat1(LookBehindTransform.apply).pack("type" -> "LookBehindTransform")
-
-    implicit val numChildrenToTheLeftFormat =
-      jsonFormat1(NumChildrenToTheLeft.apply).pack("type" -> "NumChildrenToTheLeft")
-
-    implicit val numChildrenToTheRightFormat =
-      jsonFormat1(NumChildrenToTheRight.apply).pack("type" -> "NumChildrenToTheRight")
-
-    implicit val keywordTransformFormat =
-      jsonFormat1(KeywordTransform.apply).pack("type" -> "KeywordTransform")
-
-    implicit val suffixTransformFormat =
-      jsonFormat1(SuffixTransform.apply).pack("type" -> "SuffixTransform")
-
-    implicit val prefixTransformFormat =
-      jsonFormat1(PrefixTransform.apply).pack("type" -> "PrefixTransform")
-
-    def write(transform: TokenTransform): JsValue = transform match {
-      case WordTransform => JsString("WordTransform")
-      case BreadcrumbAssigned => JsString("BreadcrumbAssigned")
-      case BreadcrumbArc => JsString("BreadcrumbArc")
-      case tp: TokenPropertyTransform => tp.toJson
-      //case fp: LookAheadTransform => fp.toJson
-      //case bp: LookBehindTransform => bp.toJson
-      case lt: NumChildrenToTheLeft => lt.toJson
-      case rt: NumChildrenToTheRight => rt.toJson
-      case kt: KeywordTransform => kt.toJson
-      case st: SuffixTransform => st.toJson
-      case pt: PrefixTransform => pt.toJson
-      case IsBracketedTransform => JsString("IsBracketedTransform")
-    }
-
-    def read(value: JsValue): TokenTransform = value match {
-      case JsString(typeid) => typeid match {
-        case "WordTransform" => WordTransform
-        case "BreadcrumbAssigned" => BreadcrumbAssigned
-        case "BreadcrumbArc" => BreadcrumbArc
-        case "IsBracketedTransform" => IsBracketedTransform
-        case x => deserializationError(s"Invalid identifier for TokenTransform: $x")
-      }
-      case jsObj: JsObject => jsObj.unpackWith(
-        tokenPropertyTransformFormat,
-        //lookAheadTransformFormat,
-        //lookBehindTransformFormat,
-        numChildrenToTheLeftFormat, numChildrenToTheRightFormat, keywordTransformFormat,
-        suffixTransformFormat, prefixTransformFormat
-      )
-      case _ => deserializationError("Unexpected JsValue type. Must be JsString or JsObject.")
-    }
-  }
+  implicit val tokenTransformJsonFormat = parentFormat[TokenTransform](
+    childFormat[WordTransform.type, TokenTransform],
+    childFormat[BreadcrumbAssigned.type, TokenTransform],
+    childFormat[BreadcrumbArc.type, TokenTransform],
+    childFormat[IsBracketedTransform.type, TokenTransform],
+    childFormat[TokenPropertyTransform, TokenTransform],
+    childFormat[NumChildrenToTheLeft, TokenTransform],
+    childFormat[NumChildrenToTheRight, TokenTransform],
+    childFormat[KeywordTransform, TokenTransform],
+    childFormat[SuffixTransform, TokenTransform],
+    childFormat[PrefixTransform, TokenTransform]
+  )
 }
 
 /** The WordTransform maps a token to its word representation.

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodExtractor.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodExtractor.scala
@@ -1,9 +1,8 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
-import org.allenai.common.json._
 import org.allenai.nlpstack.parse.poly.polyparser.{ NeighborhoodSource, Neighborhood, PolytreeParseSource, PolytreeParse }
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 /** Maps a parse tree node to one or more of its neighborhoods.
   *
@@ -16,60 +15,29 @@ import spray.json._
 trait NeighborhoodExtractor extends ((PolytreeParse, Int) => Seq[Neighborhood])
 
 object NeighborhoodExtractor {
+  private implicit val specificParentTransformFormat = jsonFormat1(SpecificParentExtractor.apply)
+  private implicit val specificChildTransformFormat = jsonFormat1(SpecificChildExtractor.apply)
+  private implicit val selfAndSpecificParentTransformFormat =
+    jsonFormat1(SelfAndSpecificParentExtractor.apply)
+  private implicit val selfAndSpecificChildTransformFormat =
+    jsonFormat1(SelfAndSpecificChildExtractor.apply)
+  private implicit val allChildrenExtractorFormat = jsonFormat0(() => AllChildrenExtractor)
+  private implicit val allParentsExtractorFormat = jsonFormat0(() => AllParentsExtractor)
+  private implicit val eachChildExtractorFormat = jsonFormat0(() => EachChildExtractor)
+  private implicit val eachParentExtractorFormat = jsonFormat0(() => EachParentExtractor)
+  private implicit val selfExtractorFormat = jsonFormat0(() => SelfExtractor)
 
-  /** Boilerplate code to serialize a NeighborhoodExtractor to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM NeighborhoodExtractor, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object NeighborhoodExtractorJsonFormat extends RootJsonFormat[NeighborhoodExtractor] {
-
-    implicit val specificParentTransformFormat =
-      jsonFormat1(SpecificParentExtractor.apply).pack("type" -> "SpecificParentExtractor")
-    implicit val specificChildTransformFormat =
-      jsonFormat1(SpecificChildExtractor.apply).pack("type" -> "SpecificChildExtractor")
-    implicit val selfAndSpecificParentTransformFormat =
-      jsonFormat1(SelfAndSpecificParentExtractor.apply).pack(
-        "type" -> "SelfAndSpecificParentExtractor"
-      )
-    implicit val selfAndSpecificChildTransformFormat =
-      jsonFormat1(SelfAndSpecificChildExtractor.apply).pack("type" ->
-        "SelfAndSpecificChildExtractor")
-
-    def write(extractor: NeighborhoodExtractor): JsValue = extractor match {
-      case specificParentExtractor: SpecificParentExtractor => specificParentExtractor.toJson
-      case specificChildExtractor: SpecificChildExtractor => specificChildExtractor.toJson
-      case selfAndSpecificParentExtractor: SelfAndSpecificParentExtractor =>
-        selfAndSpecificParentExtractor.toJson
-      case selfAndSpecificChildExtractor: SelfAndSpecificChildExtractor =>
-        selfAndSpecificChildExtractor.toJson
-      case AllChildrenExtractor => JsString("AllChildrenExtractor")
-      case AllParentsExtractor => JsString("AllParentsExtractor")
-      case EachChildExtractor => JsString("EachChildExtractor")
-      case EachParentExtractor => JsString("EachParentExtractor")
-      case SelfExtractor => JsString("SelfExtractor")
-    }
-
-    def read(value: JsValue): NeighborhoodExtractor = value match {
-      case JsString(typeid) => typeid match {
-        case "AllChildrenExtractor" => AllChildrenExtractor
-        case "AllParentsExtractor" => AllParentsExtractor
-        case "EachChildExtractor" => EachChildExtractor
-        case "EachParentExtractor" => EachParentExtractor
-        case "SelfExtractor" => SelfExtractor
-        case x => deserializationError(s"Invalid identifier for NeighborhoodExtractor: $x")
-      }
-      case jsObj: JsObject => jsObj.unpackWith(
-        specificParentTransformFormat,
-        specificChildTransformFormat,
-        selfAndSpecificParentTransformFormat,
-        selfAndSpecificChildTransformFormat
-      )
-      case _ => deserializationError("Unexpected JsValue type. Must be JsString.")
-    }
-  }
+  implicit val neighborhoodExtractorJsonFormat = parentFormat[NeighborhoodExtractor](
+    childFormat[SpecificParentExtractor, NeighborhoodExtractor],
+    childFormat[SpecificChildExtractor, NeighborhoodExtractor],
+    childFormat[SelfAndSpecificParentExtractor, NeighborhoodExtractor],
+    childFormat[SelfAndSpecificChildExtractor, NeighborhoodExtractor],
+    childFormat[AllChildrenExtractor.type, NeighborhoodExtractor],
+    childFormat[AllParentsExtractor.type, NeighborhoodExtractor],
+    childFormat[EachChildExtractor.type, NeighborhoodExtractor],
+    childFormat[EachParentExtractor.type, NeighborhoodExtractor],
+    childFormat[SelfExtractor.type, NeighborhoodExtractor]
+  )
 }
 
 /** Extracts the neighborhood (child1, ..., childK) from a parse tree, where childI is

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodTransform.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodTransform.scala
@@ -1,12 +1,11 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
-import org.allenai.common.json._
 import org.allenai.nlpstack.lemmatize.MorphaStemmer
 import org.allenai.nlpstack.core.{ Lemmatized, PostaggedToken }
 import org.allenai.nlpstack.parse.poly.ml.{ FeatureName, Verbnet }
 import org.allenai.nlpstack.parse.poly.polyparser.{ Neighborhood, PolytreeParse }
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.DefaultJsonProtocol._
 
 /** A NeighborhoodTransform maps a Neighborhood to zero or more feature names.
   *
@@ -17,54 +16,23 @@ import spray.json._
 trait NeighborhoodTransform extends ((PolytreeParse, Neighborhood) => Seq[FeatureName])
 
 object NeighborhoodTransform {
+  private implicit val arclabelNhTransformJsonFormat = jsonFormat0(() => ArclabelNhTransform)
+  private implicit val directionNhTransform = jsonFormat0(() => DirectionNhTransform)
+  private implicit val cardinalityNhTransform = jsonFormat0(() => CardinalityNhTransform)
+  private implicit val propertyNhTransformFormat = jsonFormat1(PropertyNhTransform.apply)
+  private implicit val suffixNeighborhoodTransformFormat = jsonFormat1(SuffixNhTransform.apply)
+  private implicit val keywordNeighborhoodTransformFormat = jsonFormat1(KeywordNhTransform.apply)
+  private implicit val verbnetTransformFormat = jsonFormat1(VerbnetTransform.apply)
 
-  /** Boilerplate code to serialize an EventTransform to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM EventTransform, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object NeighborhoodTransformJsonFormat extends RootJsonFormat[NeighborhoodTransform] {
-
-    implicit val propertyNhTransformFormat =
-      jsonFormat1(PropertyNhTransform.apply).pack("type" -> "PropertyNhTransform")
-    implicit val suffixNeighborhoodTransformFormat =
-      jsonFormat1(SuffixNhTransform.apply).pack("type" -> "SuffixNeighborhoodTransform")
-    implicit val keywordNeighborhoodTransformFormat =
-      jsonFormat1(KeywordNhTransform.apply).pack("type" -> "KeywordNeighborhoodTransform")
-    implicit val verbnetTransformFormat =
-      jsonFormat1(VerbnetTransform.apply).pack("type" -> "VerbnetTransform")
-
-    def write(feature: NeighborhoodTransform): JsValue = feature match {
-      case ArclabelNhTransform => JsString("ArcLabelNeighborhoodTransform")
-      case DirectionNhTransform => JsString("DirectionNeighborhoodTransform")
-      case CardinalityNhTransform => JsString("CardinalityNhTransform")
-      case propertyNhTransform: PropertyNhTransform =>
-        propertyNhTransform.toJson
-      case suffixNeighborhoodTransform: SuffixNhTransform =>
-        suffixNeighborhoodTransform.toJson
-      case keywordNeighborhoodTransform: KeywordNhTransform =>
-        keywordNeighborhoodTransform.toJson
-      case verbnetTransform: VerbnetTransform =>
-        verbnetTransform.toJson
-    }
-
-    def read(value: JsValue): NeighborhoodTransform = value match {
-      case JsString(typeid) => typeid match {
-        case "ArcLabelNeighborhoodTransform" => ArclabelNhTransform
-        case "DirectionNeighborhoodTransform" => DirectionNhTransform
-        case "CardinalityNhTransform" => CardinalityNhTransform
-        case x => deserializationError(s"Invalid identifier for NeighborhoodExtractor: $x")
-      }
-      case jsObj: JsObject => jsObj.unpackWith(
-        propertyNhTransformFormat,
-        suffixNeighborhoodTransformFormat, keywordNeighborhoodTransformFormat,
-        verbnetTransformFormat
-      )
-      case _ => deserializationError("Unexpected JsValue type. Must be JsString.")
-    }
-  }
+  implicit val neighborhoodTransformJsonFormat = parentFormat[NeighborhoodTransform](
+    childFormat[ArclabelNhTransform.type, NeighborhoodTransform],
+    childFormat[DirectionNhTransform.type, NeighborhoodTransform],
+    childFormat[CardinalityNhTransform.type, NeighborhoodTransform],
+    childFormat[PropertyNhTransform, NeighborhoodTransform],
+    childFormat[SuffixNhTransform, NeighborhoodTransform],
+    childFormat[KeywordNhTransform, NeighborhoodTransform],
+    childFormat[VerbnetTransform, NeighborhoodTransform]
+  )
 }
 
 /** Maps the tokens of a neighborhood to a particular property in their token's property map.

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/PolytreeParseFeature.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/PolytreeParseFeature.scala
@@ -1,46 +1,25 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
-import org.allenai.common.json._
 import org.allenai.nlpstack.parse.poly.ml.{ FeatureName => MLFeatureName, FeatureVector => MLFeatureVector }
 import org.allenai.nlpstack.parse.poly.polyparser.PolytreeParse
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+
+import reming.LazyFormat
+import reming.DefaultJsonProtocol._
 
 /** Maps a scored parse into a feature vector. */
 abstract class PolytreeParseFeature extends ((PolytreeParse, Double) => MLFeatureVector)
 
 object PolytreeParseFeature {
+  implicit object PolytreeParseFeatureJsonFormat extends LazyFormat[PolytreeParseFeature] {
+    implicit val polytreeParseFeatureUnionFormat = jsonFormat1(PolytreeParseFeatureUnion.apply)
+    implicit val baseParserScoreFeatureFormat = jsonFormat0(() => BaseParserScoreFeature)
+    implicit val sentenceLengthFeatureFormat = jsonFormat0(() => SentenceLengthFeature)
 
-  /** Boilerplate code to serialize a PolytreeParseFeature to JSON using Spray.
-    *
-    * NOTE: If a subclass has a field named `type`, this will fail to serialize.
-    *
-    * NOTE: IF YOU INHERIT FROM PolytreeParseFeature, THEN YOU MUST MODIFY THESE SUBROUTINES
-    * IN ORDER TO CORRECTLY EMPLOY JSON SERIALIZATION FOR YOUR NEW SUBCLASS.
-    */
-  implicit object PolytreeParseFeatureJsonFormat extends RootJsonFormat[PolytreeParseFeature] {
-
-    implicit val polytreeParseFeatureUnionFormat =
-      jsonFormat1(PolytreeParseFeatureUnion.apply).pack("type" -> "PolytreeParseFeatureUnion")
-
-    def write(feature: PolytreeParseFeature): JsValue = feature match {
-      case BaseParserScoreFeature => JsString("BaseParserScoreFeature")
-      case SentenceLengthFeature => JsString("SentenceLengthFeature")
-      case polytreeParseFeatureUnion: PolytreeParseFeatureUnion =>
-        polytreeParseFeatureUnion.toJson
-    }
-
-    def read(value: JsValue): PolytreeParseFeature = value match {
-      case JsString(typeid) => typeid match {
-        case "BaseParserScoreFeature" => BaseParserScoreFeature
-        case "SentenceLengthFeature" => SentenceLengthFeature
-        case x => deserializationError(s"Invalid identifier for TaskIdentifier: $x")
-      }
-      case jsObj: JsObject => jsObj.unpackWith(
-        polytreeParseFeatureUnionFormat
-      )
-      case _ => deserializationError("Unexpected JsValue type. Must be JsString.")
-    }
+    override val delegate = parentFormat[PolytreeParseFeature](
+      childFormat[PolytreeParseFeatureUnion, PolytreeParseFeature],
+      childFormat[BaseParserScoreFeature.type, PolytreeParseFeature],
+      childFormat[SentenceLengthFeature.type, PolytreeParseFeature]
+    )
   }
 }
 

--- a/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/ml/FeatureVectorSpec.scala
+++ b/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/ml/FeatureVectorSpec.scala
@@ -1,7 +1,8 @@
 package org.allenai.nlpstack.parse.poly.ml
 
 import org.allenai.common.testkit.UnitSpec
-import spray.json._
+
+import reming.{ CompactPrinter, JsonParser }
 
 class FeatureVectorSpec extends UnitSpec {
   // scalastyle:off
@@ -39,6 +40,6 @@ class FeatureVectorSpec extends UnitSpec {
 
   "Serializing a FeatureVector" should "preserve the vector" in {
     val vec1 = FeatureVector(Seq(nameA -> 0.5, nameB -> 0.3))
-    vec1.toJson.convertTo[FeatureVector] shouldBe vec1
+    JsonParser.read[FeatureVector](CompactPrinter.printToString(vec1)) shouldBe vec1
   }
 }

--- a/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/polyparser/ParserClassificationTaskSpec.scala
+++ b/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/polyparser/ParserClassificationTaskSpec.scala
@@ -3,7 +3,8 @@ package org.allenai.nlpstack.parse.poly.polyparser
 import org.allenai.common.testkit.UnitSpec
 import org.allenai.nlpstack.parse.poly.core.{ AnnotatedSentence, Sentence, NexusToken, Token }
 import org.allenai.nlpstack.parse.poly.fsm._
-import spray.json._
+
+import reming.{ CompactPrinter, JsonParser }
 
 class ParserClassificationTaskSpec extends UnitSpec {
   // scalastyle:off
@@ -34,12 +35,16 @@ class ParserClassificationTaskSpec extends UnitSpec {
 
   "Serializing a ApplicabilitySignature" should "preserve it" in {
     val applicabilitySig: ClassificationTask = ApplicabilitySignature(true, false, false, true)
-    applicabilitySig.toJson.convertTo[ClassificationTask] shouldBe applicabilitySig
+    JsonParser.read[ClassificationTask](CompactPrinter.printToString(applicabilitySig)) shouldBe(
+      applicabilitySig
+    )
   }
 
   "Serializing a StateRefCpos" should "preserve it" in {
     val bufferCpos: ClassificationTask = StateRefProperty(BufferRef(0), 'cpos, "det")
-    bufferCpos.toJson.convertTo[ClassificationTask] shouldBe bufferCpos
+    JsonParser.read[ClassificationTask](CompactPrinter.printToString(bufferCpos)) shouldBe(
+      bufferCpos
+    )
   }
 
   "Calling BufferCposIdentifier's apply" should "return state1's buffer top" in {
@@ -49,7 +54,9 @@ class ParserClassificationTaskSpec extends UnitSpec {
 
   "Serializing a BufferCposIdentifier" should "preserve it" in {
     val taskIdentifier: TaskIdentifier = StateRefPropertyIdentifier(BufferRef(0), 'cpos)
-    taskIdentifier.toJson.convertTo[TaskIdentifier] shouldBe taskIdentifier
+    JsonParser.read[TaskIdentifier](CompactPrinter.printToString(taskIdentifier)) shouldBe(
+      taskIdentifier
+    )
   }
 
   "Calling TaskConjunctionIdentifier's apply" should "return the proper conjunction" in {
@@ -68,7 +75,9 @@ class ParserClassificationTaskSpec extends UnitSpec {
       StateRefPropertyIdentifier(StackRef(0), 'cpos),
       StateRefPropertyIdentifier(BufferRef(0), 'cpos)
     ), None)
-    taskIdentifier.toJson.convertTo[TaskIdentifier] shouldBe taskIdentifier
+    JsonParser.read[TaskIdentifier](CompactPrinter.printToString(taskIdentifier)) shouldBe(
+      taskIdentifier
+    )
   }
 
 }

--- a/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/polyparser/StateRefSpec.scala
+++ b/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/polyparser/StateRefSpec.scala
@@ -2,7 +2,8 @@ package org.allenai.nlpstack.parse.poly.polyparser
 
 import org.allenai.common.testkit.UnitSpec
 import org.allenai.nlpstack.parse.poly.core.{ AnnotatedSentence, Sentence, NexusToken, Token }
-import spray.json._
+
+import reming.{ CompactPrinter, JsonParser }
 
 class StateRefSpec extends UnitSpec {
   // scalastyle:off
@@ -83,7 +84,7 @@ class StateRefSpec extends UnitSpec {
 
   "Serializing a StackRef" should "preserve a StackRef with index 3" in {
     val stateRef: StateRef = StackRef(3)
-    stateRef.toJson.convertTo[StateRef] shouldBe StackRef(3)
+    JsonParser.read[StateRef](CompactPrinter.printToString(stateRef)) shouldBe StackRef(3)
   }
 
   "Constructing a BufferRef" should "throw IllegalArgumentException for a negative index" in {
@@ -106,7 +107,7 @@ class StateRefSpec extends UnitSpec {
 
   "Serializing a BufferRef" should "preserve a BufferRef with index 2" in {
     val stateRef: StateRef = BufferRef(2)
-    stateRef.toJson.convertTo[StateRef] shouldBe BufferRef(2)
+    JsonParser.read[StateRef](CompactPrinter.printToString(stateRef)) shouldBe BufferRef(2)
   }
 
   "Calling LastRef's apply" should "give back the last sentence token" in {
@@ -115,7 +116,7 @@ class StateRefSpec extends UnitSpec {
 
   "Serializing a LastRef" should "preserve a LastRef" in {
     val stateRef: StateRef = LastRef
-    stateRef.toJson.convertTo[StateRef] shouldBe LastRef
+    JsonParser.read[StateRef](CompactPrinter.printToString(stateRef)) shouldBe LastRef
   }
 
   "Calling FirstRef's apply" should "give back the first (non-nexus) sentence token" in {
@@ -124,7 +125,7 @@ class StateRefSpec extends UnitSpec {
 
   "Serializing a FirstRef" should "preserve a FirstRef" in {
     val stateRef: StateRef = FirstRef
-    stateRef.toJson.convertTo[StateRef] shouldBe FirstRef
+    JsonParser.read[StateRef](CompactPrinter.printToString(stateRef)) shouldBe FirstRef
   }
 
   "Constructing a BreadcrumbRef" should "throw IllegalArgumentException for a negative index" in {
@@ -151,7 +152,7 @@ class StateRefSpec extends UnitSpec {
 
   "Serializing a BreadcrumbRef" should "preserve a BreadcrumbRef with index 4" in {
     val stateRef: StateRef = BreadcrumbRef(4)
-    stateRef.toJson.convertTo[StateRef] shouldBe BreadcrumbRef(4)
+    JsonParser.read[StateRef](CompactPrinter.printToString(stateRef)) shouldBe BreadcrumbRef(4)
   }
 
   "Calling StackGretelsRef's apply" should "give back the empty set when a valid stack item " +
@@ -169,7 +170,6 @@ class StateRefSpec extends UnitSpec {
 
   "Serializing a StackGretelsRef" should "preserve a StackGretelsRef with index 4" in {
     val stateRef: StateRef = StackGretelsRef(4)
-    stateRef.toJson.convertTo[StateRef] shouldBe StackGretelsRef(4)
+    JsonParser.read[StateRef](CompactPrinter.printToString(stateRef)) shouldBe StackGretelsRef(4)
   }
-
 }

--- a/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/polyparser/TransitionSpec.scala
+++ b/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/polyparser/TransitionSpec.scala
@@ -3,8 +3,8 @@ package org.allenai.nlpstack.parse.poly.polyparser
 import org.allenai.common.testkit.UnitSpec
 import org.allenai.nlpstack.parse.poly.core.{ AnnotatedSentence, Sentence, NexusToken, Token }
 import org.allenai.nlpstack.parse.poly.fsm.StateTransition
-import spray.json._
-import spray.json.DefaultJsonProtocol._
+
+import reming.{ CompactPrinter, JsonParser }
 
 class TransitionSpec extends UnitSpec {
   // scalastyle:off
@@ -195,8 +195,11 @@ class TransitionSpec extends UnitSpec {
   }
 
   "Serializing a list of Transitions" should "preserve it" in {
+    import reming.DefaultJsonProtocol._
     val transitions: List[StateTransition] = List(ArcEagerShift, ArcEagerReduce,
       ArcEagerLeftArc('a), ArcEagerRightArc('b))
-    transitions.toJson.convertTo[List[StateTransition]] shouldBe transitions
+    JsonParser.read[List[StateTransition]](CompactPrinter.printToString(transitions)) shouldBe (
+      transitions
+    )
   }
 }


### PR DESCRIPTION
The parser now parses with effectively zero extra memory overhead (it parsed fine with ~200M overhead). It also takes less than half the time to load (assuming you already grew your heap to accommodate the JSON AST).

@codeviking - FYI. There's a "BankerProtocol" class that provides the JSON formats you need for the banker to load the older serializations, if you're not ready to port to Reming.

@markschaake - FYI, if you're interested. :)