### PR TITLE
Fix long-line warnings in tools-parse/src/main.

### DIFF
--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
@@ -60,7 +60,9 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
     val node = findDecisionPoint(featureVector)
     val priorCounts = outcomes.toList.map(_ -> 1).toMap // add-one smoothing
     ProbabilisticClassifier.normalizeDistribution(
-      (ProbabilisticClassifier.addMaps(outcomeHistograms(node), priorCounts) mapValues { _.toDouble }).toSeq
+      (ProbabilisticClassifier.addMaps(outcomeHistograms(node), priorCounts) mapValues {
+      _.toDouble
+    }).toSeq
     ).toMap
   }
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/eval/ParseEvaluator.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/eval/ParseEvaluator.scala
@@ -145,7 +145,8 @@ case class CposAccuracy(verbose: Boolean = false) extends ParseStatistic {
           numCorrect +=
             candParse.tokens.tail.zip(goldParse.tokens.tail) count {
               case (candToken, goldToken) =>
-                candToken.getDeterministicProperty('cpos) == goldToken.getDeterministicProperty('cpos)
+                candToken.getDeterministicProperty('cpos) ==
+                  goldToken.getDeterministicProperty('cpos)
             }
           candParse.tokens.tail.zip(goldParse.tokens.tail) filter {
             case (candToken, goldToken) =>

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionSystem.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/fsm/TransitionSystem.scala
@@ -1,7 +1,12 @@
 package org.allenai.nlpstack.parse.poly.fsm
 
 import org.allenai.nlpstack.parse.poly.ml.FeatureVector
-import org.allenai.nlpstack.parse.poly.polyparser.{ ArcHybridTransitionSystemFactory, ArcEagerTransitionSystemFactory, ArcHybridTransitionSystem, ArcEagerTransitionSystem }
+import org.allenai.nlpstack.parse.poly.polyparser.{
+  ArcEagerTransitionSystem,
+  ArcEagerTransitionSystemFactory,
+  ArcHybridTransitionSystem,
+  ArcHybridTransitionSystemFactory
+}
 
 import reming.DefaultJsonProtocol._
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ArcEagerTransitionSystem.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ArcEagerTransitionSystem.scala
@@ -1,6 +1,11 @@
 package org.allenai.nlpstack.parse.poly.polyparser
 
-import org.allenai.nlpstack.parse.poly.core.{ SentenceTransform, AnnotatedSentence, WordClusters, Sentence }
+import org.allenai.nlpstack.parse.poly.core.{
+  AnnotatedSentence,
+  Sentence,
+  SentenceTransform,
+  WordClusters
+}
 import org.allenai.nlpstack.parse.poly.fsm._
 import org.allenai.nlpstack.parse.poly.ml.{ FeatureVector, BrownClusters }
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/DependencyParsingTransitionSystem.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/DependencyParsingTransitionSystem.scala
@@ -1,6 +1,11 @@
 package org.allenai.nlpstack.parse.poly.polyparser
 
-import org.allenai.nlpstack.parse.poly.core.{ SentenceTransform, AnnotatedSentence, WordClusters, Sentence }
+import org.allenai.nlpstack.parse.poly.core.{
+  AnnotatedSentence,
+  Sentence,
+  SentenceTransform,
+  WordClusters
+}
 import org.allenai.nlpstack.parse.poly.fsm._
 import org.allenai.nlpstack.parse.poly.ml.BrownClusters
 
@@ -90,8 +95,14 @@ abstract class DependencyParsingTransitionSystem(
       new OfflineTokenFeature(annotatedSentence, BufferRef(1)),
       new OfflineTokenFeature(annotatedSentence, PreviousLinkCrumbRef),
       new OfflineTokenFeature(annotatedSentence, PreviousLinkGretelRef),
-      new OfflineTokenFeature(annotatedSentence, TransitiveRef(PreviousLinkCrumbRef, Seq(TokenGretels))),
-      new OfflineTokenFeature(annotatedSentence, TransitiveRef(PreviousLinkGretelRef, Seq(TokenGretels))),
+      new OfflineTokenFeature(
+        annotatedSentence,
+        TransitiveRef(PreviousLinkCrumbRef, Seq(TokenGretels))
+      ),
+      new OfflineTokenFeature(
+        annotatedSentence,
+        TransitiveRef(PreviousLinkGretelRef, Seq(TokenGretels))
+      ),
       new OfflineTokenFeature(annotatedSentence, TransitiveRef(StackRef(0), Seq(TokenGretels))),
       new OfflineTokenFeature(annotatedSentence, TransitiveRef(StackRef(1), Seq(TokenGretels))),
       new OfflineTokenFeature(annotatedSentence, TransitiveRef(BufferRef(0), Seq(TokenGretels))),

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ParserConfiguration.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/ParserConfiguration.scala
@@ -4,7 +4,11 @@ import java.io.{ PrintWriter, File, InputStream }
 import java.net.URL
 
 import org.allenai.common.Resource._
-import org.allenai.nlpstack.parse.poly.fsm.{ StateCostFunctionFactory, RerankingFunction, StateCostFunction }
+import org.allenai.nlpstack.parse.poly.fsm.{
+  RerankingFunction,
+  StateCostFunction,
+  StateCostFunctionFactory
+}
 import reming.DefaultJsonProtocol._
 
 /** Contains the key components of a parser (for serialization purposes).

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/PolytreeParse.scala
@@ -382,10 +382,14 @@ object PolytreeParse {
         var prev: Iterator[T] = Iterator.empty
         override def hasNext = base.hasNext
         override def next() = {
-          while (prev.hasNext) prev.next() // Exhaust previous iterator; take* and drop* do NOT always work!!  (Jira SI-5002?)
+          // Exhaust previous iterator; take* and drop* do NOT always work!!  (Jira SI-5002?)
+          while (prev.hasNext) prev.next()
           prev = Iterator(base.next()) ++ new Iterator[T] {
             var hasMore = true
-            override def hasNext = { hasMore = hasMore && base.hasNext && !startsGroup(base.head); hasMore }
+            override def hasNext = {
+              hasMore = hasMore && base.hasNext && !startsGroup(base.head)
+              hasMore
+            }
             override def next() = if (hasNext) base.next() else Iterator.empty.next()
           }
           prev

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/RerankingParser.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/RerankingParser.scala
@@ -34,7 +34,9 @@ case class RerankingTransitionParser(val config: ParserConfiguration) extends Tr
     val mappedNbestList: Option[NbestList] = nbestList map { x =>
       NbestList(x.scoredSculptures)
     }
-    val candidate: Option[(Sculpture, Double)] = mappedNbestList flatMap { nbList => reranker.rerankWithScore(nbList) }
+    val candidate: Option[(Sculpture, Double)] = mappedNbestList flatMap { nbList =>
+      reranker.rerankWithScore(nbList)
+    }
     candidate match {
       case Some((parse: PolytreeParse, cost)) =>
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/StateRef.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/polyparser/StateRef.scala
@@ -255,7 +255,9 @@ case class BufferChildrenRef(val bufferIndex: Int) extends StateRef {
   require(bufferIndex >= 0, "the index of a BufferChildrenRef must be a nonnegative integer")
 
   override def apply(state: TransitionParserState): Seq[Int] = {
-    BufferRef(bufferIndex)(state) flatMap { nodeIndex => state.children.getOrElse(nodeIndex, Seq()) }
+    BufferRef(bufferIndex)(state) flatMap { nodeIndex =>
+      state.children.getOrElse(nodeIndex, Seq())
+    }
   }
 
   @transient override val name: Symbol = Symbol(s"b${bufferIndex}c")

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodEventStatistic.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodEventStatistic.scala
@@ -1,7 +1,11 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
 import org.allenai.nlpstack.parse.poly.ml.FeatureName
-import org.allenai.nlpstack.parse.poly.polyparser.{ NeighborhoodSource, ConllX, InMemoryPolytreeParseSource }
+import org.allenai.nlpstack.parse.poly.polyparser.{
+  ConllX,
+  InMemoryPolytreeParseSource,
+  NeighborhoodSource
+}
 import scopt.OptionParser
 
 /** Collects statistics over "neighborhood events."

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodExtractor.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/NeighborhoodExtractor.scala
@@ -1,6 +1,11 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
-import org.allenai.nlpstack.parse.poly.polyparser.{ NeighborhoodSource, Neighborhood, PolytreeParseSource, PolytreeParse }
+import org.allenai.nlpstack.parse.poly.polyparser.{
+  NeighborhoodSource,
+  Neighborhood,
+  PolytreeParseSource,
+  PolytreeParse
+}
 
 import reming.DefaultJsonProtocol._
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
@@ -87,7 +87,8 @@ object ParseRerankerTraining {
     val feature = defaultParseNodeFeature(verbnetTransformOption)
     val rerankingFunctionTrainer = RerankingFunctionTrainer(feature)
 
-    val nbestSource: ParsePoolSource = InMemoryParsePoolSource(FileBasedParsePoolSource(clArgs.nbestFilenames).poolIterator)
+    val nbestSource: ParsePoolSource =
+      InMemoryParsePoolSource(FileBasedParsePoolSource(clArgs.nbestFilenames).poolIterator)
     val goldParseSource = InMemoryPolytreeParseSource.getParseSource(
       clArgs.goldParseFilename,
       ConllX(true, makePoly = true), clArgs.dataSource
@@ -110,45 +111,47 @@ object ParseRerankerTraining {
     RerankingFunction.save(rerankingFunction, clArgs.rerankerFilename)
   }
 
-  def defaultParseNodeFeature(verbnetTransformOption: Option[(String, VerbnetTransform)]) = new ParseNodeFeatureUnion(Seq(
-    TransformedNeighborhoodFeature(Seq(
-      ("children", AllChildrenExtractor)
-    ), Seq(
-      ("card", CardinalityNhTransform)
-    )),
-    TransformedNeighborhoodFeature(Seq(
-      ("self", SelfExtractor),
-      ("parent", EachParentExtractor),
-      ("child", EachChildExtractor),
-      ("parent1", SpecificParentExtractor(0)),
-      ("parent2", SpecificParentExtractor(1)),
-      ("parent3", SpecificParentExtractor(2)),
-      ("parent4", SpecificParentExtractor(3)),
-      ("child1", SpecificChildExtractor(0)),
-      ("child2", SpecificChildExtractor(1)),
-      ("child3", SpecificChildExtractor(2)),
-      ("child4", SpecificChildExtractor(3)),
-      ("child5", SpecificChildExtractor(4))
-    ), Seq(
-      ("cpos", PropertyNhTransform('cpos)),
-      ("suffix", SuffixNhTransform(WordClusters.suffixes.toSeq map { _.name })),
-      ("keyword", KeywordNhTransform(WordClusters.stopWords.toSeq map { _.name }))
-    ) ++ verbnetTransformOption),
-    TransformedNeighborhoodFeature(Seq(
-      ("parent1", SelfAndSpecificParentExtractor(0)),
-      ("parent2", SelfAndSpecificParentExtractor(1)),
-      ("parent3", SelfAndSpecificParentExtractor(2)),
-      ("parent4", SelfAndSpecificParentExtractor(3)),
-      ("child1", SelfAndSpecificChildExtractor(0)),
-      ("child2", SelfAndSpecificChildExtractor(1)),
-      ("child3", SelfAndSpecificChildExtractor(2)),
-      ("child4", SelfAndSpecificChildExtractor(3)),
-      ("child5", SelfAndSpecificChildExtractor(4))
-    ), Seq(
-      ("alabel", ArclabelNhTransform),
-      ("direction", DirectionNhTransform)
+  def defaultParseNodeFeature(verbnetTransformOption: Option[(String, VerbnetTransform)]) = {
+    new ParseNodeFeatureUnion(Seq(
+      TransformedNeighborhoodFeature(Seq(
+        ("children", AllChildrenExtractor)
+      ), Seq(
+        ("card", CardinalityNhTransform)
+      )),
+      TransformedNeighborhoodFeature(Seq(
+        ("self", SelfExtractor),
+        ("parent", EachParentExtractor),
+        ("child", EachChildExtractor),
+        ("parent1", SpecificParentExtractor(0)),
+        ("parent2", SpecificParentExtractor(1)),
+        ("parent3", SpecificParentExtractor(2)),
+        ("parent4", SpecificParentExtractor(3)),
+        ("child1", SpecificChildExtractor(0)),
+        ("child2", SpecificChildExtractor(1)),
+        ("child3", SpecificChildExtractor(2)),
+        ("child4", SpecificChildExtractor(3)),
+        ("child5", SpecificChildExtractor(4))
+      ), Seq(
+        ("cpos", PropertyNhTransform('cpos)),
+        ("suffix", SuffixNhTransform(WordClusters.suffixes.toSeq map { _.name })),
+        ("keyword", KeywordNhTransform(WordClusters.stopWords.toSeq map { _.name }))
+      ) ++ verbnetTransformOption),
+      TransformedNeighborhoodFeature(Seq(
+        ("parent1", SelfAndSpecificParentExtractor(0)),
+        ("parent2", SelfAndSpecificParentExtractor(1)),
+        ("parent3", SelfAndSpecificParentExtractor(2)),
+        ("parent4", SelfAndSpecificParentExtractor(3)),
+        ("child1", SelfAndSpecificChildExtractor(0)),
+        ("child2", SelfAndSpecificChildExtractor(1)),
+        ("child3", SelfAndSpecificChildExtractor(2)),
+        ("child4", SelfAndSpecificChildExtractor(3)),
+        ("child5", SelfAndSpecificChildExtractor(4))
+      ), Seq(
+        ("alabel", ArclabelNhTransform),
+        ("direction", DirectionNhTransform)
+      ))
     ))
-  ))
+  }
 
   def createTrainingData(goldParseSource: PolytreeParseSource, parsePools: ParsePoolSource,
     feature: ParseNodeFeature): TrainingData = {
@@ -181,7 +184,8 @@ object ParseRerankerTraining {
         parsePairs flatMap {
           case (candidateParse, goldParse) =>
             val badTokens: Set[Int] =
-              (candidateParse.families.toSet -- goldParse.families.toSet) map { // TODO: consider labels as well?
+              // TODO: consider labels as well?
+              (candidateParse.families.toSet -- goldParse.families.toSet) map {
                 case family =>
                   family.tokens.head
               }
@@ -218,7 +222,11 @@ case class RerankingFunctionTrainer(parseNodeFeature: ParseNodeFeature) {
   ): (RerankingFunction, WrapperClassifier) = {
 
     println("Creating training vectors.")
-    val trainingData = ParseRerankerTraining.createTrainingData(goldParseSource, nbestSource, parseNodeFeature)
+    val trainingData = ParseRerankerTraining.createTrainingData(
+      goldParseSource,
+      nbestSource,
+      parseNodeFeature
+    )
     //trainingData.labeledVectors foreach { case (vec, label) =>
     //  println(vec)
     //}

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/PolytreeParseFeature.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/PolytreeParseFeature.scala
@@ -1,6 +1,9 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
-import org.allenai.nlpstack.parse.poly.ml.{ FeatureName => MLFeatureName, FeatureVector => MLFeatureVector }
+import org.allenai.nlpstack.parse.poly.ml.{
+  FeatureName => MLFeatureName,
+  FeatureVector => MLFeatureVector
+}
 import org.allenai.nlpstack.parse.poly.polyparser.PolytreeParse
 
 import reming.LazyFormat

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/QualityEstimation.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/QualityEstimation.scala
@@ -1,7 +1,11 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
 import org.allenai.nlpstack.parse.poly.eval._
-import org.allenai.nlpstack.parse.poly.fsm.{ BaseCostRerankingFunction, Sculpture, RerankingFunction }
+import org.allenai.nlpstack.parse.poly.fsm.{
+  BaseCostRerankingFunction,
+  RerankingFunction,
+  Sculpture
+}
 import org.allenai.nlpstack.parse.poly.polyparser._
 import scopt.OptionParser
 
@@ -77,13 +81,19 @@ object QualityEstimation {
         case (candidateParse, modelCost) =>
           (candidateParse, rerankingFunction(candidateParse, modelCost))
       }
-      val sortedCandidates = scoredCandidates.toSeq sortBy { case (_, score) => score } map { case (cand, _) => cand }
+      val sortedCandidates = scoredCandidates.toSeq sortBy {
+        case (_, score) => score
+      } map { case (cand, _) => cand }
 
       val percentagesToPlot = Seq(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
       val pathAccuracies = percentagesToPlot map { percentage =>
         val candidateSubset = sortedCandidates.take((percentage * sortedCandidates.size).toInt)
-        val numerator = (candidateSubset map { candidate => scoringFunction.getRatio(candidate)._1 }).sum
-        val denominator = (candidateSubset map { candidate => scoringFunction.getRatio(candidate)._2 }).sum
+        val numerator = (candidateSubset map { candidate =>
+          scoringFunction.getRatio(candidate)._1
+        }).sum
+        val denominator = (candidateSubset map { candidate =>
+          scoringFunction.getRatio(candidate)._2
+        }).sum
         numerator.toFloat / denominator
       }
 
@@ -106,7 +116,8 @@ private case object SentenceLengthRerankingFunction extends RerankingFunction {
   }
 }
 
-private case class ParseScoreRerankingFunction(scoringFunction: ParseScore) extends RerankingFunction {
+private case class ParseScoreRerankingFunction(scoringFunction: ParseScore)
+    extends RerankingFunction {
   override def apply(sculpture: Sculpture, baseCost: Double): Double = {
     sculpture match {
       case parse: PolytreeParse =>


### PR DESCRIPTION
There were a lot of these, and they hid a useful warning (don't use `JavaConversions`).