### PR TITLE
Justifying Classifier Outcomes

### DIFF
--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
@@ -66,7 +66,9 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
     ).toMap
   }
 
-  override def outcomeDistributionWithJustification(featureVector: FeatureVector): Map[Int, (Double, DecisionTreeJustification)] = {
+  override def outcomeDistributionWithJustification(
+    featureVector: FeatureVector
+  ): Map[Int, (Double, DecisionTreeJustification)] = {
     val (node, breadCrumb) =
       findDecisionPointWithBreabcrumb(featureVector, 0, Seq.empty[(Int, Int)])
     val priorCounts = outcomes.toList.map(_ -> 1).toMap // add-one smoothing
@@ -106,7 +108,9 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
     }
   }
 
-  protected def selectChildWithPath(nodeId: Int, featureVector: FeatureVector): Option[(Int, (Int, Int))] = {
+  protected def selectChildWithPath(
+    nodeId: Int, featureVector: FeatureVector
+  ): Option[(Int, (Int, Int))] = {
     for {
       feature <- splittingFeature(nodeId)
       child <- child(nodeId).get(featureVector.getFeature(feature))

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
@@ -5,7 +5,7 @@ import scala.annotation.tailrec
 
 /** Structure to represent a decision tree's justification for a certain classification outcome.
   * Contains index of the chosen node and the breadcrumb that led to it:
-  * (feature index, feature value) tuple at each decision point. 
+  * (feature index, feature value) tuple at each decision point.
   */
 case class DecisionTreeJustification(breadCrumb: Seq[(Int, Int)], node: Int) extends Justification
 

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
@@ -4,6 +4,8 @@ import spray.json._
 import scala.annotation.tailrec
 
 /** Structure to represent a decision tree's justification for a certain classification outcome.
+  * Contains index of the chosen node and the breadcrumb that led to it:
+  * (feature index, feature value) tuple at each decision point. 
   */
 case class DecisionTreeJustification(breadCrumb: Seq[(Int, Int)], node: Int) extends Justification
 
@@ -55,9 +57,10 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
 
   // For use in KL Divergence calculation. Calculating Root distribution upfront to avoid having
   // to calculate during every call to getNodeDivergenceScore.
-   @transient val outcomeDistributionRoot = (ProbabilisticClassifier.normalizeDistribution(
-     (outcomeHistograms(0) mapValues { _.toDouble }).toSeq)).toMap
-        
+  @transient val outcomeDistributionRoot = (ProbabilisticClassifier.normalizeDistribution(
+    (outcomeHistograms(0) mapValues { _.toDouble }).toSeq
+  )).toMap
+
   /** Gets a probability distribution over possible outcomes..
     *
     * @param featureVector feature vector to compute the distribution for
@@ -92,9 +95,10 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
    */
   def getNodeDivergenceScore(node: Int): Double = {
     val outcomeDistributionThisNode = (ProbabilisticClassifier.normalizeDistribution(
-        (outcomeHistograms(node) mapValues { _.toDouble }).toSeq)).toMap
+      (outcomeHistograms(node) mapValues { _.toDouble }).toSeq
+    )).toMap
     val klDivergence = (for {
-      (k,q) <- outcomeDistributionRoot
+      (k, q) <- outcomeDistributionRoot
       p <- outcomeDistributionThisNode.get(k)
       if ((q != 0) && (p != 0))
     } yield {

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
@@ -75,6 +75,9 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
     ).toMap
   }
 
+  /** Get the probability distribution for the various outcomes together with the justification
+    * for each.
+    */
   override def outcomeDistributionWithJustification(
     featureVector: FeatureVector
   ): Map[Int, (Double, DecisionTreeJustification)] = {
@@ -90,7 +93,7 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
     }).toMap
   }
 
-  /* Return node divergence against root node. This is: 
+  /* Return node divergence against root node. This is calculated as: 
    * Total no. of outcomes * KL Divergence for requested node against the root node of the tree.
    */
   def getNodeDivergenceScore(node: Int): Double = {
@@ -134,7 +137,16 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
     }
   }
 
-  protected def selectChildWithPath(
+  /** Enhanced version of the selectChild method above that returns not only the selected child's
+    * node index but also the feature index and value in the path that led to that node.
+    * and the node's splitting feature (if there is one).
+    *
+    * @param nodeId the id of the node
+    * @param featureVector the feature vector
+    * @return the node id of the correct child (if there is one), together with a tuple containing
+    * the index of the feature and feature value that led to that node from the previous node.
+    */
+  protected def getChildWithPathInfo(
     nodeId: Int, featureVector: FeatureVector
   ): Option[(Int, (Int, Int))] = {
     for {
@@ -160,10 +172,16 @@ case class DecisionTree(outcomes: Iterable[Int], child: IndexedSeq[Map[Int, Int]
     }
   }
 
+  /** Enhanced version of findDecisionPoint that finds both the decision point and the cumulative
+    * path all the way from the root that led to this point.
+    *
+    * @param featureVector feature vector to classify
+    * @return the decision tree node that the feature vector is classified into
+    */
   @tailrec protected final def findDecisionPointWithBreabcrumb(
     featureVector: FeatureVector, nodeId: Int = 0, breadCrumb: Seq[(Int, Int)]
   ): (Int, Seq[(Int, Int)]) = {
-    selectChildWithPath(nodeId, featureVector) match {
+    getChildWithPathInfo(nodeId, featureVector) match {
       case None => (nodeId, breadCrumb)
       case Some((child, path)) =>
         findDecisionPointWithBreabcrumb(featureVector, child, breadCrumb :+ path)

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
@@ -36,7 +36,8 @@ trait Justification
   */
 trait JustifyingProbabilisticClassifier extends ProbabilisticClassifier {
 
-  /** Gets the probability distribution over outcomes.
+  /** Gets the probability distribution over outcomes, with justification for each outcome in the
+    * distribution.
     *
     * @param featureVector feature vector to find outcome distribution for
     * @return probability distribution of outcomes according to training data with associated

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
@@ -42,7 +42,9 @@ trait JustifyingProbabilisticClassifier extends ProbabilisticClassifier {
     * @return probability distribution of outcomes according to training data with associated
     * explanations for each outcome.
     */
-  def outcomeDistributionWithJustification(featureVector: FeatureVector): Map[Int, (Double, Justification)]
+  def outcomeDistributionWithJustification(
+    featureVector: FeatureVector
+  ): Map[Int, (Double, Justification)]
 
   /** Classifies a feature vector and produces a justification for the result produced.
     *

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
@@ -32,7 +32,8 @@ trait ProbabilisticClassifier {
   */
 trait Justification
 
-/** Justifying classifier extends ProbabilisticClassifier
+/** Probabilistic Classifier that classifies a given feature vector and provides justification for
+  * the obtained outcome.
   */
 trait JustifyingProbabilisticClassifier extends ProbabilisticClassifier {
 
@@ -123,6 +124,8 @@ object ProbabilisticClassifier {
   }
 }
 
+/** Companion object to the JustifyingProbabilisticClassifier to enable proper deserialization.
+  */
 object JustifyingProbabilisticClassifier {
   import ProbabilisticClassifier.ProbabilisticClassifierJsonFormat
   import ProbabilisticClassifier.ProbabilisticClassifierJsonFormat._

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
@@ -87,8 +87,8 @@ case class RandomForest(allOutcomes: Seq[Int], decisionTrees: Seq[DecisionTree])
       }
   }
 
-  /* Aggregate counts for each outcome (by summing them up), and aggregate the
-   * decision tree justifications by creating a RandomForestJustification out of them.
+  /* Aggregate counts for each outcome, and aggregate the decision tree justifications
+   * by creating a RandomForestJustification out of them.
    * 
    * @param outcomeHistogram  a map of each outcome to a seq of indivdual occurrences of that
    * outcome from various decision trees, with the decision tree justification for each,

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
@@ -53,8 +53,9 @@ case class RandomForest(allOutcomes: Seq[Int], decisionTrees: Seq[DecisionTree])
     RandomForest.normalizeHistogram(outcomeHistogram)
   }
 
-  /** Each decision gets a single vote about the outcome. The produced distribution is the
-    * normalized histogram of the votes.
+  /** As in the outcomeDistribution method, returns the produced distribution as a
+    * normalized histogram of the votes from individual decision trees. In addition, produces
+    * a justification for each outcome, by aggregating decision tree justifications.
     *
     * @param featureVector feature vector to find outcome distribution for
     * @return a probability distribution over outcomes, and justifications for the outcomes.

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
@@ -45,14 +45,13 @@ case class RandomForest(allOutcomes: Seq[Int], decisionTrees: Seq[DecisionTree])
     * @param featureVector feature vector to find outcome distribution for
     * @return a probability distribution over outcomes, together with explanations for the outcomes.
     */
-  override def outcomeDistributionWithJustification(featureVector: FeatureVector): Map[Int, (Double, RandomForestJustification)] = {
+  override def outcomeDistributionWithJustification(
+    featureVector: FeatureVector
+  ): Map[Int, (Double, RandomForestJustification)] = {
     // Call 'classifyAndJustify' on each decision tree in the forest, group by outcomes, and
     // aggregate total counts of the number of trees producing each outcome, and aggregate
     // corresponding justifications from the individual decision trees.
-    decisionTrees map {
-      decisionTree => decisionTree.classifyAndJustify(featureVector)
-    }
-    val outcomeHistogram: Map[Int, Seq[(Int, Justification)]] =
+    val outcomeHistogram =
       decisionTrees map { decisionTree => decisionTree.classifyAndJustify(featureVector)
       } groupBy { x => x._1 }
     val outcomeHistogramWithDtJustifications: Map[Int, (Int, RandomForestJustification)] =
@@ -64,14 +63,16 @@ case class RandomForest(allOutcomes: Seq[Int], decisionTrees: Seq[DecisionTree])
       }
   }
 
-  // Aggregate justifications for each outcome by performing the following steps-
-  // 1. Use a fold operation to get a Seq of all justifications from all the individual decision
-  //  trees.
-  // 2. Convert the Seq[Justification] to a Seq[DecisionTreeJustification].
-  // 3. Create a RandomForestJustification out of the Seq of DecisionTreeJustifications.
+  /* Aggregate justifications for each outcome
+   */
   private def aggregateJustifications(
     outcomeHistogram: Map[Int, Seq[(Int, Justification)]]
   ): Map[Int, (Int, RandomForestJustification)] = {
+    // Aggregate justifications by performing the following steps -
+    // 1. Use a fold operation to get a Seq of all justifications from all the individual decision
+    //  trees.
+    // 2. Convert the Seq[Justification] to a Seq[DecisionTreeJustification].
+    // 3. Create a RandomForestJustification out of the Seq of DecisionTreeJustifications.
     (outcomeHistogram mapValues { v =>
       (v.size, v.foldLeft(Seq.empty[Justification])((dtJustifications, dtOutcomeAndJustification) =>
         dtJustifications :+ dtOutcomeAndJustification._2))

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/RandomForest.scala
@@ -91,7 +91,7 @@ case class RandomForest(allOutcomes: Seq[Int], decisionTrees: Seq[DecisionTree])
    * decision tree justifications by creating a RandomForestJustification out of them.
    * 
    * @param outcomeHistogram  a map of each outcome to a seq of indivdual occurrences of that
-   * outcome, with from various decision trees, the decision tree justification for each,
+   * outcome from various decision trees, with the decision tree justification for each,
    * and the score for the decision tree node chosen for each case.
    * @param numDecisionTreesToConsiderForJustification  an optional integer specifying a number
    * for the top n decision tree justifications to propagate to the random forest justification. The

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
@@ -101,41 +101,6 @@ case class JustifyingWrapperClassifier(
       }
   }
 
-  def prettyPrintDecisionTreeJustification(
-    justification: DecisionTreeJustification
-  ): String = {
-    // Map the feature indexes to their feature names
-    val featureTuples: Seq[(FeatureName, Int)] = justification.breadCrumb.map {
-      case (featureNameIx: Int, featureVal: Int) =>
-        (featureNameForIndex(featureNameIx), featureVal)
-    }
-    "[ " + (for {
-      featureTuple <- featureTuples
-    } yield {
-      featureTuple._1 + " = " + featureTuple._2
-    }).mkString(", ") + " ]"
-  }
-
-  def prettyPrintRandomForestJustification(
-    justification: RandomForestJustification
-  ): String = {
-    s"\nRandom Forest with ${justification.totalDecisionTreeCount} trees, of which " +
-      s"${justification.decisionTreeCountForOutcome} trees voted for the current outcome\n" +
-      s"Top ${justification.decisionTreeJustifications.size} decision tree justification(s):\n" +
-      "[\n" + justification.decisionTreeJustifications.map(j =>
-        prettyPrintDecisionTreeJustification(j)).mkString(",\n\n") + "\n]\n"
-  }
-
-  def prettyPrintJustification(justification: Justification): String = {
-    justification match {
-      case dtJustification: DecisionTreeJustification =>
-        prettyPrintDecisionTreeJustification(dtJustification)
-      case rfJustification: RandomForestJustification =>
-        prettyPrintRandomForestJustification(rfJustification)
-      case _ => ""
-    }
-  }
-
   /** Returns a distribution over all (integer) outcomes, given the input feature vector.
     *
     * @param featureVector the feature vector to classify
@@ -176,6 +141,46 @@ case class JustifyingWrapperClassifier(
       getExplainableDecisionTreeJustification(dtJustification)
     }
   }
+
+  /** Stringifies a Decision Tree justification into a set of feature-value pairs corresponding
+    * to every decision in the breadcrumb that led to a classification outcome.
+    */
+  def prettyPrintDecisionTreeJustification(
+    justification: DecisionTreeJustification
+  ): String = {
+    // Map the feature indexes to their feature names
+    val featureMap = getExplainableDecisionTreeJustification(justification)
+    "[ " + (for {
+      (featureName, featureVal) <- featureMap
+    } yield {
+      featureName + " = " + featureVal
+    }).mkString(", ") + " ]"
+  }
+
+  /** Stringifies a Random Forest justification.
+    */
+  def prettyPrintRandomForestJustification(
+    justification: RandomForestJustification
+  ): String = {
+    s"\nRandom Forest with ${justification.totalDecisionTreeCount} trees, of which " +
+      s"${justification.decisionTreeCountForOutcome} trees voted for the current outcome\n" +
+      s"Top ${justification.decisionTreeJustifications.size} decision tree justification(s):\n" +
+      "[\n" + justification.decisionTreeJustifications.map(j =>
+        prettyPrintDecisionTreeJustification(j)).mkString(",\n\n") + "\n]\n"
+  }
+
+  /** Stringifies a classifier's justification.
+    */
+  def prettyPrintJustification(justification: Justification): String = {
+    justification match {
+      case dtJustification: DecisionTreeJustification =>
+        prettyPrintDecisionTreeJustification(dtJustification)
+      case rfJustification: RandomForestJustification =>
+        prettyPrintRandomForestJustification(rfJustification)
+      case _ => ""
+    }
+  }
+
 }
 
 /** Provide Serialization and Deserialization methods based on the runtime type of

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
@@ -1,35 +1,45 @@
 package org.allenai.nlpstack.parse.poly.ml
 
+import org.allenai.common.json._
 import org.allenai.nlpstack.parse.poly.decisiontree.{
   FeatureVector => DTFeatureVector,
   ProbabilisticClassifierTrainer,
+  JustifyingProbabilisticClassifierTrainer,
   InMemoryFeatureVectorSource,
   SparseVector,
-  ProbabilisticClassifier
+  ProbabilisticClassifier,
+  JustifyingProbabilisticClassifier,
+  Justification,
+  DecisionTreeJustification,
+  RandomForestJustification
 }
 import org.allenai.nlpstack.parse.poly.fsm.SimpleTask
+import spray.json._
 import spray.json.DefaultJsonProtocol._
 import scala.collection.immutable.HashSet
 
 /** A WrapperClassifier wraps a ProbabilisticClassifier (which uses integer-based feature
   * names) in an interface that allows you to use the more natural
   * org.allenai.nlpstack.parse.poly.ml FeatureVector format for classification.
-  *
-  * @param classifier the embedded classifier (which uses integer-based feature names)
-  * @param featureNameMap a map from the integer feature names to their string-based form
+  * This is a trait that specific wrappers can extend.
   */
-case class WrapperClassifier(
-    classifier: ProbabilisticClassifier,
-    featureNameMap: Seq[(Int, FeatureName)]
-) {
+sealed trait WrapperClassifier {
+  def classifier(): ProbabilisticClassifier
+  def featureNameMap(): Seq[(Int, FeatureName)]
 
   /** The inverse of featureNameMap. */
   @transient
-  private val featureNameToIndex: Map[FeatureName, Int] =
+  protected val featureNameToIndex: Map[FeatureName, Int] =
     (featureNameMap map {
       case (featIndex, feat) =>
         (feat, featIndex)
     }).toMap
+
+  /** Returns a feature name based on an index. */
+  protected def featureNameForIndex(index: Int): FeatureName = {
+    val map = featureNameMap.toMap
+    map(index)
+  }
 
   /** Returns the most probable (integer) outcome, given the input feature vector.
     *
@@ -42,7 +52,7 @@ case class WrapperClassifier(
     )
   }
 
-  /** Returns a distributions over all (integer) outcomes, given the input feature vector.
+  /** Returns a distribution over all (integer) outcomes, given the input feature vector.
     *
     * @param featureVector the feature vector to classify
     * @return the most probable (integer) outcome
@@ -53,9 +63,124 @@ case class WrapperClassifier(
     )
   }
 }
+/* A case class extending the WrapperClassifier trait. Does not support any new functionality.
+  * @param classifier the embedded classifier (which uses integer-based feature names)
+  * @param featureNameMap a map from the integer feature names to their string-based form
+  */
+case class BasicWrapperClassifier(
+    classifier: ProbabilisticClassifier,
+    featureNameMap: Seq[(Int, FeatureName)]
+) extends WrapperClassifier {
+}
+
+/* A case class extending the WrapperClassifier trait, that supports methods to classify and
+  * provide justification for the classification.
+  * @param classifier a justifying classifier (which uses integer-based feature names)
+  * @param featureNameMap a map from the integer feature names to their string-based form
+  */
+case class JustifyingWrapperClassifier(
+    classifier: JustifyingProbabilisticClassifier,
+    featureNameMap: Seq[(Int, FeatureName)]
+) extends WrapperClassifier {
+
+  /** Given the input feature vector, returns the most probable (integer) outcome, along
+    * with a justification for the outcome.
+    *
+    * @param featureVector the feature vector to classify
+    * @return a tuple containing the most probable (integer) outcome and the justification
+    * (a text explanation) for that outcome.
+    */
+  def classifyAndJustify(featureVector: FeatureVector): (Int, String) = {
+    (classifier.classifyAndJustify(
+      WrapperClassifier.createDTFeatureVector(featureVector, featureNameToIndex, None)
+    )) match {
+        case (outcome: Int, justification: DecisionTreeJustification) =>
+          (outcome, prettyPrintDecisionTreeJustification(justification))
+        case (outcome: Int, justification: RandomForestJustification) =>
+          (outcome, prettyPrintRandomForestJustification(justification))
+        case (outcome: Int, _) => (outcome, "")
+      }
+  }
+
+  private def prettyPrintDecisionTreeJustification(justification: DecisionTreeJustification): String = {
+    // Map the feature indexes to their feature names
+    val featureTuples: Seq[(FeatureName, Int)] = justification.breadCrumb.map {
+      case (featureNameIx: Int, featureVal: Int) =>
+        (featureNameForIndex(featureNameIx), featureVal)
+    }
+
+    // Group the tuples by the first symbol, which generally indicates the node in the
+    // polytree, for e.g., "self", "parent1", "child1", "child2", etc.
+    /*val featureTuplesGrouped: Map[Symbol, Seq[(String, Int)]] =
+        featureTuples.groupBy(_._1.symbols.head) mapValues {
+          case tuples: Seq[(FeatureName,Int)] =>
+            tuples map { t => (new FeatureName(t._1.symbols.tail).toString, t._2) }
+        }
+
+      // Build the Justification string by composing justification for each type of node.
+      val featureTuplesStr = (for {
+        (k, v) <- featureTuplesGrouped
+      } yield {
+        "[ " + k.name + ": " +
+         "[ " + (v map {
+           case (featureNameStr: String, featureVal: Int) => featureNameStr + " = " + featureVal
+         }).mkString(", ") + " ] ]"
+       }).mkString(",\n")
+       "[\n" + featureTuplesStr + "\n]\n"*/
+
+    "[ " + (for {
+      featureTuple <- featureTuples
+    } yield {
+      featureTuple._1 + " = " + featureTuple._2
+    }).mkString(", ") + " ]"
+  }
+
+  private def prettyPrintRandomForestJustification(justification: RandomForestJustification): String =
+    {
+      "[\n" + justification.dtJustifications.map(j =>
+        prettyPrintDecisionTreeJustification(j)).mkString(",\n\n") + "\n]\n"
+    }
+
+  /** Returns a distribution over all (integer) outcomes, given the input feature vector.
+    *
+    * @param featureVector the feature vector to classify
+    * @return a tuple with the most probable (integer) outcome and the classifier justification for
+    *   the outcome
+    */
+  def getDistributionWithJustification(featureVector: FeatureVector): Map[Int, (Double, String)] = {
+    classifier.outcomeDistributionWithJustification(
+      WrapperClassifier.createDTFeatureVector(featureVector, featureNameToIndex, None)
+    ) map {
+        case (outcome: Int, (confidence: Double, justification: DecisionTreeJustification)) =>
+          (outcome, (confidence, prettyPrintDecisionTreeJustification(justification)))
+        case (outcome: Int, (confidence: Double, justification: RandomForestJustification)) =>
+          (outcome, (confidence, prettyPrintRandomForestJustification(justification)))
+      }
+  }
+}
 
 object WrapperClassifier {
-  implicit val wcFormat = jsonFormat2(WrapperClassifier.apply)
+
+  implicit object WrapperClassifierJsonFormat
+      extends RootJsonFormat[WrapperClassifier] {
+
+    implicit val basicWCformat = jsonFormat2(BasicWrapperClassifier.apply).pack("type" -> "basic")
+
+    import ProbabilisticClassifier.ProbabilisticClassifierJsonFormat._
+
+    implicit val justifyingWCformat =
+      jsonFormat2(JustifyingWrapperClassifier.apply).pack("type" -> "justifying")
+
+    def write(classifier: WrapperClassifier): JsValue = classifier match {
+      case basic: BasicWrapperClassifier => basic.toJson
+      case justifying: JustifyingWrapperClassifier => justifying.toJson
+      case x => deserializationError(s"Cannot serialize this classifier type: $x")
+    }
+
+    def read(value: JsValue): WrapperClassifier = {
+      value.asJsObject.unpackWith(basicWCformat, justifyingWCformat)
+    }
+  }
 
   /** Converts a string-based feature vector into an integer-based feature vector.
     *
@@ -83,7 +208,9 @@ object WrapperClassifier {
   *
   * @param classifierTrainer the underlying trainer to use (from the decisiontree package)
   */
-class WrapperClassifierTrainer(classifierTrainer: ProbabilisticClassifierTrainer) {
+class WrapperClassifierTrainer(
+    classifierTrainer: ProbabilisticClassifierTrainer
+) {
 
   def apply(trainingData: TrainingData): WrapperClassifier = {
     val featureNames: Seq[FeatureName] = trainingData.featureNames.toSeq
@@ -104,6 +231,15 @@ class WrapperClassifierTrainer(classifierTrainer: ProbabilisticClassifierTrainer
       } map {
         _.swap
       }
-    WrapperClassifier(inducedClassifier, featureMap)
+    inducedClassifier match {
+      case c: JustifyingProbabilisticClassifier =>
+        new JustifyingWrapperClassifier(
+          inducedClassifier.asInstanceOf[JustifyingProbabilisticClassifier], featureMap
+        )
+      case _ =>
+        BasicWrapperClassifier(inducedClassifier, featureMap)
+
+    }
   }
 }
+

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
@@ -120,6 +120,9 @@ case class JustifyingWrapperClassifier(
   def prettyPrintRandomForestJustification(
     justification: RandomForestJustification
   ): String = {
+    s"\nRandom Forest with ${justification.totalDtCount} trees, of which " +
+    s"${justification.dtCountForOutcome} trees voted for the current outcome\n" +
+    s"Top ${justification.dtJustifications.size} decision tree justification(s):\n" +
     "[\n" + justification.dtJustifications.map(j =>
       prettyPrintDecisionTreeJustification(j)).mkString(",\n\n") + "\n]\n"
   }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/ml/WrapperClassifier.scala
@@ -120,11 +120,11 @@ case class JustifyingWrapperClassifier(
   def prettyPrintRandomForestJustification(
     justification: RandomForestJustification
   ): String = {
-    s"\nRandom Forest with ${justification.totalDtCount} trees, of which " +
-    s"${justification.dtCountForOutcome} trees voted for the current outcome\n" +
-    s"Top ${justification.dtJustifications.size} decision tree justification(s):\n" +
-    "[\n" + justification.dtJustifications.map(j =>
-      prettyPrintDecisionTreeJustification(j)).mkString(",\n\n") + "\n]\n"
+    s"\nRandom Forest with ${justification.totalDecisionTreeCount} trees, of which " +
+      s"${justification.decisionTreeCountForOutcome} trees voted for the current outcome\n" +
+      s"Top ${justification.decisionTreeJustifications.size} decision tree justification(s):\n" +
+      "[\n" + justification.decisionTreeJustifications.map(j =>
+        prettyPrintDecisionTreeJustification(j)).mkString(",\n\n") + "\n]\n"
   }
 
   def prettyPrintJustification(justification: Justification): String = {
@@ -151,7 +151,7 @@ case class JustifyingWrapperClassifier(
     )
   }
 
-  /** Takes a Decision Tree Justification and turns into a map of feature-value pairs by
+  /** Takes a Decision Tree Justification and turns it into a map of feature-value pairs by
     * mapping feature indexes to respective (String) names based on the featureNameMap
     * field.
     */
@@ -165,7 +165,7 @@ case class JustifyingWrapperClassifier(
     }).toMap
   }
 
-  /** Takes a Random Forest Justification and turns into a seq of explainable decision tree
+  /** Takes a Random Forest Justification and turns it into a seq of explainable decision tree
     * justifications, as defined in getExplainableDecisionTreeJustification-- there is an
     * explainable decision tree justification for each decision tree in the random forest that
     * voted for the chosen outcome.
@@ -173,12 +173,15 @@ case class JustifyingWrapperClassifier(
   def getExplainableRandomForestJustification(
     justification: RandomForestJustification
   ): Seq[Map[FeatureName, Int]] = {
-    justification.dtJustifications map { dtJustification =>
+    justification.decisionTreeJustifications map { dtJustification =>
       getExplainableDecisionTreeJustification(dtJustification)
     }
   }
 }
 
+/** Provide Serialization and Deserialization methods based on the runtime type of
+  * WrapperClassifier.
+  */
 object WrapperClassifier {
 
   implicit object WrapperClassifierJsonFormat

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
@@ -1,8 +1,18 @@
 package org.allenai.nlpstack.parse.poly.reranking
 
 import org.allenai.nlpstack.parse.poly.core.Sentence
+import org.allenai.nlpstack.parse.poly.decisiontree.{
+  DecisionTreeJustification,
+  Justification,
+  RandomForestJustification
+}
 import org.allenai.nlpstack.parse.poly.eval._
 import org.allenai.nlpstack.parse.poly.fsm.RerankingFunction
+import org.allenai.nlpstack.parse.poly.ml.{
+  FeatureName,
+  JustifyingWrapperClassifier,
+  WrapperClassifier
+}
 import org.allenai.nlpstack.parse.poly.polyparser._
 
 import java.io._
@@ -97,18 +107,18 @@ case class WeirdnessAnalyzer(rerankingFunction: WeirdParseNodeRerankingFunction)
         }
 
       val falsePositiveMessages = weirdGoldNodes map {
-        case (goldNodeIx, justification) =>
+        case (goldNodeIx, justificationOption) =>
           s"  ${goldParse.printFamily(goldNodeIx)}" +
-            s"\nClassifier Justification: ${justification.getOrElse("")}\n"
+            s"\nClassifier Explanation: ${prettyPrintWeirdnessExplanation(justificationOption)}\n"
       }
       val trueNegativeNodesAndJustifications = notWeirdCandidateNodes filter {
         node => badCandidateTokens.contains(node._1)
       }
       val trueNegativeMessages = trueNegativeNodesAndJustifications map {
-        case (misclassifiedNodeIx, justification) =>
+        case (misclassifiedNodeIx, justificationOption) =>
           s"  ${candParse.printFamily(misclassifiedNodeIx)}\n" +
             s"    (should be: ${goldParse.printFamily(misclassifiedNodeIx)})" +
-            s" \nClassifier Justification: ${justification.getOrElse("")}\n"
+            s" \nClassifier Explanation: ${prettyPrintWeirdnessExplanation(justificationOption)}\n"
       }
 
       if (falsePositiveMessages.nonEmpty || trueNegativeMessages.nonEmpty) {
@@ -141,4 +151,134 @@ case class WeirdnessAnalyzer(rerankingFunction: WeirdParseNodeRerankingFunction)
   override def reset(): Unit = {
     sentencesWithMistakes = Seq[(Sentence, Set[String], Set[String])]()
   }
+
+  /** Helper method used to check whether the WrapperClassifier in use is a
+    * JustifyingWrapperClassifier.
+    */
+  private def getJustifyingClassifier(
+    classifier: WrapperClassifier
+  ): Option[JustifyingWrapperClassifier] = {
+    classifier match {
+      case justifyingClassifier: JustifyingWrapperClassifier => Some(justifyingClassifier)
+      case _ => None
+    }
+  }
+
+  /** Helper Method used to custom print a DecisionTreeJustification for Weirdness analysis.
+    *
+    * For a Justification that looks like:
+    * [ parent1.cpos.nexus = 0, child.cpos.. = 0, parent2.cpos.. = 0, self.cpos.notFound = 0,
+    * parent2.alabel.ADVMOD = 0, child1.direction.R = 0, self.cpos.VERB = 0,
+    * parent.cpos.notFound = 0, children.card.0 = 0, children.card.1 = 1, parent.suffix.s = 0,
+    * parent.cpos.ADP = 0, self.keyword.'s = 0, child1.alabel.AMOD = 0, child1.alabel.DEP = 0,
+    * child1.alabel.NSUBJ = 0, parent.cpos.. = 0, child.keyword.was = 0, child1.alabel.TMOD = 0,
+    * child1.alabel.COP = 0, child1.alabel.POSSESSIVE = 0, child1.keyword.is = 0,
+    * child1.alabel.PRT = 0, self.cpos.CONJ = 0, child1.alabel.VMOD = 0, child.cpos.NOUN = 0,
+    * self.cpos.ADP = 1, child1.keyword.did = 0, child.keyword.are = 0, self.keyword.at = 1 ]
+    *
+    * Explanation generated will look like:
+    * [
+    * [ children.card = 1 ],
+    * [ self.cpos = ADP ],
+    * [ self.keyword = at ],
+    * [ child.cpos <> {NOUN, .} ],
+    * [ child.keyword <> {are, was} ],
+    * [ child1.alabel <> {VMOD, AMOD, NSUBJ, COP, DEP, POSSESSIVE, TMOD, PRT} ],
+    * [ child1.direction <> R ],
+    * [ child1.keyword <> {did, is} ],
+    * [ parent.cpos <> {., notFound, ADP} ],
+    * [ parent.suffix <> s ],
+    * [ parent1.cpos <> nexus ],
+    * [ parent2.alabel <> ADVMOD ],
+    * [ parent2.cpos <> . ]
+    * ]
+    */
+  private def prettyPrintDecisionTreeWeirdnessExplanation(
+    dtJustification: DecisionTreeJustification,
+    justifyingClassifier: JustifyingWrapperClassifier
+  ): String = {
+    val explainableJustification =
+      justifyingClassifier.getExplainableDecisionTreeJustification(dtJustification)
+    // Group the tuples by the first + second symbol,  which indicate the node in the polytree,
+    // and the property in question, respectively,for e.g.,
+    // "self.cpos", "parent1.direction", etc.
+    val featureValuesGrouped =
+      (explainableJustification.groupBy(_._1.symbols.take(2)) map {
+        case (k, v) => (new FeatureName(k), v)
+      }) mapValues {
+        case featureValueMap: Map[FeatureName, Int] =>
+          featureValueMap map { t => (new FeatureName(t._1.symbols.drop(2)).toString, t._2) }
+      }
+
+    // Helper Method to format output feature values.
+    def setBeginMarker(featureVals: Seq[(String, Int)]): String = {
+      if (featureVals.size > 1) "{"
+      else ""
+    }
+
+    // Helper Method to format output feature values.
+    def setEndMarker(featureVals: Seq[(String, Int)]): String = {
+      if (featureVals.size > 1) "}"
+      else ""
+    }
+
+    // Build the final explanation (string) by composing justification for each type of node.
+    // For each key- first + second symbol of the FeatureName, for e.g., "self" and "cpos",
+    // in the feature map, get the various binary property values, for e.g., "ADJ=0", "ADV =1", etc.
+    // Group map elements by the true/false property values for a more meaningful display.
+    // Within each group (true/false), sort the keys alphabetically, for e.g., "parent1.direction"
+    // should appear before "self.cpos".
+    val explanationsGroupedByTrueFalseProperty = (for {
+      (k, v) <- featureValuesGrouped
+    } yield {
+      val featureNameStr = k.toString
+      // If there exists any property in the map that has a value of '1' (is true), then show
+      // only that property as true. If not, construct a friendly representation for
+      // all off properties.
+      val vSeq = v.toSeq
+      val featureValStrAndTrueFalseProperty = vSeq.find(x => x._2 == 1) match {
+        case Some(trueProperty) => (" = " + trueProperty._1, true)
+        case _ => (" <> " + setBeginMarker(vSeq) + vSeq.map(x => x._1).mkString(", ") +
+          setEndMarker(vSeq), false)
+      }
+      (featureNameStr, featureValStrAndTrueFalseProperty._1, featureValStrAndTrueFalseProperty._2)
+    }).groupBy(x => x._3).mapValues(v => v.toSeq.sortBy(_._1).map(y => (y._1, y._2)))
+
+    val trueFeatureValueExplanations = for {
+      truePropertyExplanation <- explanationsGroupedByTrueFalseProperty.getOrElse(
+        true, Seq.empty[(String, String)]
+      )
+    } yield {
+      "  [ " + truePropertyExplanation._1 + truePropertyExplanation._2 + " ]"
+    }
+    val falseFeatureValueExplanations = for {
+      falsePropertyExplanation <- explanationsGroupedByTrueFalseProperty.getOrElse(false, Seq.empty[(String, String)])
+    } yield {
+      "  [ " + falsePropertyExplanation._1 + falsePropertyExplanation._2 + " ]"
+    }
+
+    "\n[\n" +
+      (trueFeatureValueExplanations ++ falseFeatureValueExplanations).mkString(",\n") +
+      "\n]"
+  }
+
+  /** Method used to custom print a random forest's justification for Weirdness
+    * analysis.
+    */
+  def prettyPrintWeirdnessExplanation(justificationOption: Option[Justification]): String = {
+    (for {
+      justifyingClassifier <- getJustifyingClassifier(rerankingFunction.classifier)
+      justification <- justificationOption
+    } yield {
+      justification match {
+        case dtJustification: DecisionTreeJustification =>
+          prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)
+        case rfJustification: RandomForestJustification =>
+          "[ " + rfJustification.dtJustifications.map(dtJustification =>
+            prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)).
+            mkString(", ") + " ]"
+      }
+    }).getOrElse("")
+  }
+
 }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
@@ -252,7 +252,8 @@ case class WeirdnessAnalyzer(rerankingFunction: WeirdParseNodeRerankingFunction)
       "  [ " + truePropertyExplanation._1 + truePropertyExplanation._2 + " ]"
     }
     val falseFeatureValueExplanations = for {
-      falsePropertyExplanation <- explanationsGroupedByTrueFalseProperty.getOrElse(false, Seq.empty[(String, String)])
+      falsePropertyExplanation <- explanationsGroupedByTrueFalseProperty.getOrElse(
+          false, Seq.empty[(String, String)])
     } yield {
       "  [ " + falsePropertyExplanation._1 + falsePropertyExplanation._2 + " ]"
     }
@@ -274,6 +275,9 @@ case class WeirdnessAnalyzer(rerankingFunction: WeirdParseNodeRerankingFunction)
         case dtJustification: DecisionTreeJustification =>
           prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)
         case rfJustification: RandomForestJustification =>
+           s"\nRandom Forest with ${rfJustification.totalDtCount} trees, of which " +
+           s"${rfJustification.dtCountForOutcome} trees voted for the current outcome\n" +
+           s"Top ${rfJustification.dtJustifications.size} decision tree justification(s):\n" +
           "[ " + rfJustification.dtJustifications.map(dtJustification =>
             prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)).
             mkString(", ") + " ]"

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
@@ -253,7 +253,8 @@ case class WeirdnessAnalyzer(rerankingFunction: WeirdParseNodeRerankingFunction)
     }
     val falseFeatureValueExplanations = for {
       falsePropertyExplanation <- explanationsGroupedByTrueFalseProperty.getOrElse(
-          false, Seq.empty[(String, String)])
+        false, Seq.empty[(String, String)]
+      )
     } yield {
       "  [ " + falsePropertyExplanation._1 + falsePropertyExplanation._2 + " ]"
     }
@@ -275,11 +276,11 @@ case class WeirdnessAnalyzer(rerankingFunction: WeirdParseNodeRerankingFunction)
         case dtJustification: DecisionTreeJustification =>
           prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)
         case rfJustification: RandomForestJustification =>
-           s"\nRandom Forest with ${rfJustification.totalDtCount} trees, of which " +
-           s"${rfJustification.dtCountForOutcome} trees voted for the current outcome\n" +
-           s"Top ${rfJustification.dtJustifications.size} decision tree justification(s):\n" +
-          "[ " + rfJustification.dtJustifications.map(dtJustification =>
-            prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)).
+          s"\nRandom Forest with ${rfJustification.totalDtCount} trees, of which " +
+            s"${rfJustification.dtCountForOutcome} trees voted for the current outcome\n" +
+            s"Top ${rfJustification.dtJustifications.size} decision tree justification(s):\n" +
+            "[ " + rfJustification.dtJustifications.map(dtJustification =>
+              prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)).
             mkString(", ") + " ]"
       }
     }).getOrElse("")

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseReranker.scala
@@ -276,10 +276,12 @@ case class WeirdnessAnalyzer(rerankingFunction: WeirdParseNodeRerankingFunction)
         case dtJustification: DecisionTreeJustification =>
           prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)
         case rfJustification: RandomForestJustification =>
-          s"\nRandom Forest with ${rfJustification.totalDtCount} trees, of which " +
-            s"${rfJustification.dtCountForOutcome} trees voted for the current outcome\n" +
-            s"Top ${rfJustification.dtJustifications.size} decision tree justification(s):\n" +
-            "[ " + rfJustification.dtJustifications.map(dtJustification =>
+          s"\nRandom Forest with ${rfJustification.totalDecisionTreeCount} trees, of which " +
+            s"${rfJustification.decisionTreeCountForOutcome} trees " +
+            s"voted for the current outcome\n" +
+            s"Top ${rfJustification.decisionTreeJustifications.size} " +
+            s"decision tree justification(s):\n" +
+            "[ " + rfJustification.decisionTreeJustifications.map(dtJustification =>
               prettyPrintDecisionTreeWeirdnessExplanation(dtJustification, justifyingClassifier)).
             mkString(", ") + " ]"
       }

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/reranking/ParseRerankerTraining.scala
@@ -281,21 +281,25 @@ case class WeirdParseNodeRerankingFunction(
     */
   def getNodes(parse: PolytreeParse): Set[(Int, Int, Float, Option[Justification])] = {
     (Range(0, parse.tokens.size).toSet map { tokenIndex: Int =>
-      val distWithJustification : Map[Int, (Float, Option[Justification])]= classifier match {
+      val distWithJustification: Map[Int, (Float, Option[Justification])] = classifier match {
         case c: JustifyingWrapperClassifier =>
           c.asInstanceOf[JustifyingWrapperClassifier].getDistributionWithJustification(
-            feature(parse, tokenIndex)) mapValues (v => (v._1, Option(v._2)))
+            feature(parse, tokenIndex)
+          ) mapValues (v => (v._1, Option(v._2)))
         case _ =>
           classifier.getDistribution(feature(parse, tokenIndex)).mapValues(
-              v => (v, None))
+            v => (v, None)
+          )
       }
       (for {
         outcome <- distWithJustification.keys
       } yield {
-        (tokenIndex,
+        (
+          tokenIndex,
           outcome,
           distWithJustification(outcome)._1,
-          distWithJustification(outcome)._2)
+          distWithJustification(outcome)._2
+        )
       }).toSet
     }).flatten
   }

--- a/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/decisiontree/OneVersusAllSpec.scala
+++ b/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/decisiontree/OneVersusAllSpec.scala
@@ -11,7 +11,7 @@ import org.allenai.common.testkit.UnitSpec
   * @param feature4 the fourth-highest priority feature
   */
 case class MockBinaryProbabilisticClassifier(val feature1: Int, val feature2: Int,
-    val feature3: Int, val feature4: Int) extends BasicProbabilisticClassifier {
+    val feature3: Int, val feature4: Int) extends ProbabilisticClassifier {
 
   /** Gets the probability distribution over outcomes.
     *

--- a/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/decisiontree/OneVersusAllSpec.scala
+++ b/tools/parse/src/test/scala/org/allenai/nlpstack/parse/poly/decisiontree/OneVersusAllSpec.scala
@@ -11,7 +11,7 @@ import org.allenai.common.testkit.UnitSpec
   * @param feature4 the fourth-highest priority feature
   */
 case class MockBinaryProbabilisticClassifier(val feature1: Int, val feature2: Int,
-    val feature3: Int, val feature4: Int) extends ProbabilisticClassifier {
+    val feature3: Int, val feature4: Int) extends BasicProbabilisticClassifier {
 
   /** Gets the probability distribution over outcomes.
     *


### PR DESCRIPTION
@mhrmm : Here it is. Pruned Random Forest justification to top (highest KL divergence) decision tree node as discussed.

Output looks like this:

```
Who was made the first honorary citizen of the U.S. ?
Good families, classified as weird:
  nexus[nexus] -> ROOT:made[VERB]
Classifier Explanation:
Random Forest with 12 trees, of which 12 trees voted for the current outcome
Top 1 decision tree justification(s):
[
[
  [ child1.cpos = VERB ],
  [ self.cpos = nexus ],
  [ child.cpos <> NOUN ],
  [ child.keyword <> {have, are, is, what, must, do, has, did, can, on, me, from, were, let} ],
  [ child.suffix <> {y, ing, tion, al, ion, ive} ],
  [ child1.alabel <> DEP ],
  [ child1.keyword <> {down, in, would, own, had, to, most, was, there, been, should, with, could, into, does, when, of, and, the} ],
  [ child1.suffix <> {est, s, ed, ic, ment, er} ],
  [ child3.alabel <> DEP ],
  [ children.card <> 0 ],
  [ parent.keyword <> of ],
  [ parent2.alabel <> PUNCT ]
] ]
```

Formatting output in above form for easier weirdness analysis is implemented outside of the `JustifyingWrapperClassifier` itself because the assumptions we make here might be specific to these features.