### PR TITLE
Adds Stanford segmenter

### DIFF
--- a/cli/src/main/scala/org/allenai/nlpstack/cli/SegmenterMain.scala
+++ b/cli/src/main/scala/org/allenai/nlpstack/cli/SegmenterMain.scala
@@ -11,9 +11,9 @@ abstract class SegmenterMain
 }
 
 object FactorieSegmenterMain extends SegmenterMain {
-  val sentencer = new FactorieSegmenter()
+  override val sentencer = new FactorieSegmenter()
 }
 
 object StanfordSegmenterMain extends SegmenterMain {
-  val sentencer = StanfordSegmenter
+  override val sentencer = StanfordSegmenter
 }

--- a/cli/src/main/scala/org/allenai/nlpstack/cli/SegmenterMain.scala
+++ b/cli/src/main/scala/org/allenai/nlpstack/cli/SegmenterMain.scala
@@ -1,8 +1,7 @@
 package org.allenai.nlpstack.cli
 
 import org.allenai.nlpstack.core._
-import org.allenai.nlpstack.segment.ChalkSentenceSegmenter
-import org.allenai.nlpstack.segment.FactorieSegmenter
+import org.allenai.nlpstack.segment.{ StanfordSegmenter, ChalkSentenceSegmenter, FactorieSegmenter }
 
 abstract class SegmenterMain
     extends LineProcessor("segmenter") {
@@ -13,4 +12,8 @@ abstract class SegmenterMain
 
 object FactorieSegmenterMain extends SegmenterMain {
   val sentencer = new FactorieSegmenter()
+}
+
+object StanfordSegmenterMain extends SegmenterMain {
+  val sentencer = StanfordSegmenter
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -48,7 +48,7 @@ object NlpstackBuild extends Build {
           "https://github.com/allenai/nlpstack.git"
         )),
         conflictManager := ConflictManager.strict,
-        libraryDependencies ++= testingLibraries,
+        libraryDependencies ++= (testingLibraries ++ loggingDependencies),
         ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value,
         pomExtra :=
           <developers>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -147,7 +147,11 @@ object NlpstackBuild extends Build {
     base = file("tools/segment"),
     settings = buildSettings ++ Seq(
       name := "nlpstack-segment",
-      libraryDependencies ++= Seq(factorie, commonsIo % "test")
+      libraryDependencies ++= Seq(
+        factorie,
+        stanfordCoreNlp,
+        commonsIo % "test"
+      )
     )
   ) dependsOn (core)
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -6,6 +6,7 @@ jdk:
 cache:
   directories:
   - $HOME/.ivy2/cache
+  - $HOME/.ai2/datastore
 env:
   - secure: Me9yvnJjmGkBz5CY1qKNfFFvy3DUgA33lhPTPPuI1+MJWPp2hi1EtANaO6rmV7GhdQBITL6llEyyGSAuKJbt8XL11axFtdF3WnQd/rXXR0gnk1GhsaSLZ/38lYZ4V+IH5ptPhimr2wOXhZgzK9H4b4bk+YGWgWX0V0LieQiJNarRsiUVOSuyhgz/VCWnMbFKEhP6ZzNc5Cm90ZNgcQjkY72GmUngNIadWW7lrSDo9vCzAY87wXvyCvIMF0feui2ancMjt1AAQjhiqNzpB7rVrly48la0b0s//tqctetT9YJlitRpo08q887JEtTjM3Gkk9QcZITn6GizMAWw9SKyvg==
 before_install:

--- a/tools/chunk/src/test/resources/logback.xml
+++ b/tools/chunk/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache.wire" level="WARN" additivity="false" />
+</configuration>

--- a/tools/core/src/test/resources/logback.xml
+++ b/tools/core/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache.wire" level="WARN" additivity="false" />
+</configuration>

--- a/tools/lemmatize/src/test/resources/logback.xml
+++ b/tools/lemmatize/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache.wire" level="WARN" additivity="false" />
+</configuration>

--- a/tools/parse/src/test/resources/logback.xml
+++ b/tools/parse/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache.wire" level="WARN" additivity="false" />
+</configuration>

--- a/tools/postag/src/test/resources/logback.xml
+++ b/tools/postag/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache.wire" level="WARN" additivity="false" />
+</configuration>

--- a/tools/segment/src/main/scala/org/allenai/nlpstack/segment/StanfordSegmenter.scala
+++ b/tools/segment/src/main/scala/org/allenai/nlpstack/segment/StanfordSegmenter.scala
@@ -1,0 +1,34 @@
+package org.allenai.nlpstack.segment
+
+import java.util.Properties
+
+import edu.stanford.nlp.ling.CoreAnnotations
+
+import scala.collection.JavaConverters._
+
+import edu.stanford.nlp.ling.CoreAnnotations.SentencesAnnotation
+import edu.stanford.nlp.pipeline.{ Annotation, StanfordCoreNLP }
+import org.allenai.nlpstack.core.{ Segment, Segmenter }
+
+object StanfordSegmenter extends Segmenter {
+  /* This is a bit unfortunate. In Stanford, you tokenize first, and then
+   * segment. In nlpstack, it's the other way around. We solve the problem by
+   * tokenizing twice, once here to get the sentences, and then again in
+   * StanfordTokenizer. */
+
+  private val pipeline = {
+    val props = new Properties()
+    props.put("annotators", "tokenize, ssplit")
+    new StanfordCoreNLP(props)
+  }
+
+  override def segment(document: String): Iterable[Segment] = {
+    val annotation = new Annotation(document)
+    pipeline.annotate(annotation)
+    annotation.get(classOf[SentencesAnnotation]).asScala.map { sentence =>
+      val start = sentence.get(classOf[CoreAnnotations.CharacterOffsetBeginAnnotation])
+      val end = sentence.get(classOf[CoreAnnotations.CharacterOffsetEndAnnotation])
+      Segment(document.substring(start, end), start)
+    }
+  }
+}

--- a/tools/segment/src/main/scala/org/allenai/nlpstack/segment/StanfordSegmenter.scala
+++ b/tools/segment/src/main/scala/org/allenai/nlpstack/segment/StanfordSegmenter.scala
@@ -3,12 +3,11 @@ package org.allenai.nlpstack.segment
 import java.util.Properties
 
 import edu.stanford.nlp.ling.CoreAnnotations
-
-import scala.collection.JavaConverters._
-
 import edu.stanford.nlp.ling.CoreAnnotations.SentencesAnnotation
 import edu.stanford.nlp.pipeline.{ Annotation, StanfordCoreNLP }
 import org.allenai.nlpstack.core.{ Segment, Segmenter }
+
+import scala.collection.JavaConverters._
 
 object StanfordSegmenter extends Segmenter {
   /* This is a bit unfortunate. In Stanford, you tokenize first, and then

--- a/tools/segment/src/test/resources/logback.xml
+++ b/tools/segment/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache.wire" level="WARN" additivity="false" />
+</configuration>

--- a/tools/tokenize/src/test/resources/logback.xml
+++ b/tools/tokenize/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache.wire" level="WARN" additivity="false" />
+</configuration>


### PR DESCRIPTION
Replacing the Factorie tokenizer with Stanford only solved half my problem. We also use the Factorie segmenter, which in turn calls the Factorie tokenizer. So this puts in the Stanford segmenter as well.

It still has the problem of tokenizing twice, but fixing that would be a bigger change.

@jkinkead, can you look at this? Thanks!