### PR TITLE
Add basic README for `nlpstack/cli`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,11 @@
 # CLI Usage
 
+To build:
+
+```
+sbt "cli/compile"
+```
+
 Command-line to run any of the CLIs:
 
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,7 +6,7 @@ Command-line to run any of the CLIs:
 sbt "cli/runMain <mainClassName> --input <input-file-path> -- output <output-file-path>
 ```
 
-For e.g., to run the `Stanford POS Tagger`:
+For e.g., to run the Stanford POS Tagger:
 
 ```
 sbt "cli/runMain org.allenai.nlpstack.cli.StanfordPostaggerMain  --input /path/to/input.txt --output /path/to/output.txt"
@@ -57,7 +57,7 @@ Multiple main classes detected, select one to run:
 Enter number: 
 ```
 
-Note, for e.g., that this shows that there is also a Factorie POS Tagger. If you would like to run that, you can type 2 at the above prompt, and hit enter.
+Note, for e.g., that this shows that there is also a Factorie POS Tagger. If you would like to run that, you can type `2` at the above prompt, and hit enter.
 
 
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,102 @@
+Command-line to run any of the CLIs:
+
+```
+sbt "cli/runMain <mainClassName> --input <input-file-path> -- output <output-file-path>
+```
+
+For e.g., to run the `Stanford POS Tagger`:
+
+```
+sbt "cli/runMain org.allenai.nlpstack.cli.StanfordPostaggerMain  --input /Users/sumithrab/nlpstack/posTaggerIp.txt --output /Users/sumithrab/nlpstack/posTaggerOp.txt"
+```
+
+The input file is generally a text file with one sentence per line. To run a segmenter, you can give it any block of text.
+
+
+You can also alternately do the following:
+
+```
+sbt "cli/run --input /Users/sumithrab/nlpstack/posTaggerIp.txt --output /Users/sumithrab/nlpstack/posTaggerOp.txt"
+```
+
+which will show you all entry points under the `cli` subproject for you to choose from:
+
+```
+Multiple main classes detected, select one to run:
+
+ [1] org.allenai.nlpstack.cli.FactorieParserMain
+
+ [2] org.allenai.nlpstack.cli.FactoriePostaggerMain
+
+ [3] org.allenai.nlpstack.cli.FactorieSegmenterMain
+
+ [4] org.allenai.nlpstack.cli.FactorieTokenizerMain
+
+ [5] org.allenai.nlpstack.cli.KnowitallArgumentHeadExtractorMain
+
+ [6] org.allenai.nlpstack.cli.KnowitallRelationHeadExtractorMain
+
+ [7] org.allenai.nlpstack.cli.MorphaStemmerMain
+
+ [8] org.allenai.nlpstack.cli.OpenNlpChunkerMain
+
+ [9] org.allenai.nlpstack.cli.PennTokenizerMain
+
+ [10] org.allenai.nlpstack.cli.PolytreeParserMain
+
+ [11] org.allenai.nlpstack.cli.StanfordPostaggerMain
+
+ [12] org.allenai.nlpstack.cli.StanfordSegmenterMain
+
+ [13] org.allenai.nlpstack.cli.StanfordTokenizerMain
+
+ [14] org.allenai.nlpstack.cli.WhitespaceTokenizerMain
+
+Enter number: 
+```
+
+Note, for e.g., that this shows that there is also a Factorie POS Tagger. If you would like to run that, you can type 2 at the above prompt, and hit enter.
+
+
+
+You can also run a specific CLI listed above with the `--help` flag to find out how to run it, for e.g.:
+
+```
+sbt "cli/runMain org.allenai.nlpstack.cli.StanfordPostaggerMain  --help"
+```
+
+This will give you the following usage info:
+
+```
+[info] Usage: postagger [options]
+
+[info] 
+
+[info]   --server
+
+[info]         run as a server
+
+[info]   --port <value>
+
+[info]         port to run the server on
+
+[info]   --input <value>
+
+[info]         file to input from
+
+[info]   --output <value>
+
+[info]         file to output to
+
+[info]   --rawInput <value>
+
+[info]         raw input to process
+
+[info]   --parallel
+
+[info]         parallel execution
+
+[info]   --help
+
+[info]         print this usage text
+```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,3 +1,5 @@
+# CLI Usage
+
 Command-line to run any of the CLIs:
 
 ```
@@ -7,7 +9,7 @@ sbt "cli/runMain <mainClassName> --input <input-file-path> -- output <output-fil
 For e.g., to run the `Stanford POS Tagger`:
 
 ```
-sbt "cli/runMain org.allenai.nlpstack.cli.StanfordPostaggerMain  --input /Users/sumithrab/nlpstack/posTaggerIp.txt --output /Users/sumithrab/nlpstack/posTaggerOp.txt"
+sbt "cli/runMain org.allenai.nlpstack.cli.StanfordPostaggerMain  --input /path/to/input.txt --output /path/to/output.txt"
 ```
 
 The input file is generally a text file with one sentence per line. To run a segmenter, you can give it any block of text.
@@ -16,7 +18,7 @@ The input file is generally a text file with one sentence per line. To run a seg
 You can also alternately do the following:
 
 ```
-sbt "cli/run --input /Users/sumithrab/nlpstack/posTaggerIp.txt --output /Users/sumithrab/nlpstack/posTaggerOp.txt"
+sbt "cli/run --input /path/to/input.txt --output /path/to/output.txt"
 ```
 
 which will show you all entry points under the `cli` subproject for you to choose from:


### PR DESCRIPTION
@dirkgr : this adds some very basic documentation to use the programs under the `cli` subproject. Julia was trying to run a POS Tagger and didn't know where to begin because we don't have any README.
@juliahai2 FYI