### PR TITLE
Improve performance of core addMaps functions.

### DIFF
--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/DecisionTree.scala
@@ -60,14 +60,12 @@ case class DecisionTreeJustification(decisionTree: DecisionTree, node: Int) exte
 
     // Helper Method to format output feature values.
     def setBeginMarker(featureVals: Seq[(String, Int)]): String = {
-      if (featureVals.size > 1) "{"
-      else ""
+      if (featureVals.size > 1) "{" else ""
     }
 
     // Helper Method to format output feature values.
     def setEndMarker(featureVals: Seq[(String, Int)]): String = {
-      if (featureVals.size > 1) "}"
-      else ""
+      if (featureVals.size > 1) "}" else ""
     }
 
     // Build the final explanation (string) by composing justification for each type of node.

--- a/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
+++ b/tools/parse/src/main/scala/org/allenai/nlpstack/parse/poly/decisiontree/ProbabilisticClassifier.scala
@@ -105,15 +105,17 @@ object ProbabilisticClassifier {
   }
 
   def addMaps(m1: Map[Int, Int], m2: Map[Int, Int]): Map[Int, Int] = {
-    ((m1.keys ++ m2.keys).toSet map { key: Int =>
-      (key, m1.getOrElse(key, 0) + m2.getOrElse(key, 0))
-    }).toMap
+    val (larger, smaller) = if (m1.size > m2.size) (m1, m2) else (m2, m1)
+    val commonKeys = larger.keySet & smaller.keySet
+    val added = commonKeys.map { key => key -> (larger(key) + smaller(key)) }
+    larger ++ smaller ++ added
   }
 
   def addFloatMaps(m1: Map[Int, Float], m2: Map[Int, Float]): Map[Int, Float] = {
-    ((m1.keys ++ m2.keys).toSet map { key: Int =>
-      (key, m1.getOrElse(key, 0f) + m2.getOrElse(key, 0f))
-    }).toMap
+    val (larger, smaller) = if (m1.size > m2.size) (m1, m2) else (m2, m1)
+    val commonKeys = larger.keySet & smaller.keySet
+    val added = commonKeys.map { key => key -> (larger(key) + smaller(key)) }
+    larger ++ smaller ++ added
   }
 }
 

--- a/tools/postag/src/main/scala/org/allenai/nlpstack/postag/StanfordPostagger.scala
+++ b/tools/postag/src/main/scala/org/allenai/nlpstack/postag/StanfordPostagger.scala
@@ -7,7 +7,7 @@ import org.allenai.nlpstack.core._
 import org.allenai.datastore.Datastore
 
 import java.net.URL
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class StanfordPostagger(
     val tagger: MaxentTagger
@@ -16,15 +16,14 @@ class StanfordPostagger(
   def this() = this(StanfordPostagger.loadDefaultModel())
 
   override def postagTokenized(tokens: Seq[Token]): Seq[PostaggedToken] = {
-    val postags = tagger.tagSentence(
-      tokens.map { token =>
-      val corelabel = new CoreLabel();
-      corelabel.setWord(token.string);
+    val labels = tokens.map { token =>
+      val corelabel = new CoreLabel()
+      corelabel.setWord(token.string)
       corelabel
-    }.toList
-    ).map(_.tag())
+    }
+    val postags = tagger.tagSentence(labels.asJava).asScala.map(_.tag())
 
-    (tokens zip postags) map {
+    (tokens zip postags).map {
       case (token, postag) =>
         PostaggedToken(token, postag)
     }


### PR DESCRIPTION
Context: `addMaps` is executed extremely frequently, comprising about 35% of our execution time in a client service.  We can reduce this function in many cases by an order of magnitude with a slight rework.

Performance analysis can be found [here](https://github.com/allenai/aimichal/tree/master/addmaps).
@aimichal FYI